### PR TITLE
Use id_token for api call

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -25,6 +25,7 @@ impl AdditionalClaims for OktaClaims {}
 #[derive(Debug)]
 pub struct AuthInfo {
     pub account: String,
+    pub id_token: String,
     pub access_token: String,
     pub expiry_time: String,
     pub refresh_token: String,
@@ -32,6 +33,7 @@ pub struct AuthInfo {
 
 #[derive(Debug)]
 pub struct TokenInfo {
+    pub id_token: String,
     pub access_token: String,
     pub expiry_time: String,
     pub refresh_token: String,
@@ -199,6 +201,7 @@ pub async fn login<'a>() -> Result<AuthInfo, CliError<'a>> {
 
     Ok(AuthInfo {
         account: current_user_email.to_string(),
+        id_token: id_token.to_string(),
         access_token: access_token.secret().to_owned(),
         expiry_time: expiry.to_string(),
         refresh_token: refresh_token.secret().to_owned(),
@@ -233,6 +236,11 @@ pub async fn refresh_tokens(refresh_token: &RefreshToken) -> Result<TokenInfo, C
             unreachable!();
         });
 
+    let id_token = token_response
+        .extra_fields()
+        .id_token()
+        .expect("Server did not return an ID token");
+
     let refresh_token = token_response
         .refresh_token()
         .expect("Server did not return a refresh token");
@@ -250,6 +258,7 @@ pub async fn refresh_tokens(refresh_token: &RefreshToken) -> Result<TokenInfo, C
         .to_rfc3339();
 
     Ok(TokenInfo {
+        id_token: id_token.to_string(),
         access_token: access_token.secret().to_owned(),
         expiry_time: expiry.to_string(),
         refresh_token: refresh_token.secret().to_owned(),

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -36,6 +36,7 @@ pub async fn handle_init<'a>(
 
         config.auth = Some(AuthConfig {
             account: auth_info.account.clone(),
+            id_token: auth_info.id_token,
             access_token: auth_info.access_token,
             expiry_time: auth_info.expiry_time,
             refresh_token: auth_info.refresh_token,
@@ -48,7 +49,7 @@ pub async fn handle_init<'a>(
 
     // Calling API ...
     let client = QueryClientBuilder::new()
-        .with_access_token(config.auth.as_ref().unwrap().access_token.clone())
+        .with_access_token(config.auth.as_ref().unwrap().id_token.clone())
         .build()?;
 
     let applications_data: Vec<String> = client

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -44,6 +44,7 @@ async fn login_and_update_config<'a>() -> Result<bool, CliError<'a>> {
     CLIConfig::load(&config_file).map(|mut config| {
         config.auth = Some(AuthConfig {
             account: auth_info.account.clone(),
+            id_token: auth_info.id_token,
             access_token: auth_info.access_token,
             expiry_time: auth_info.expiry_time,
             refresh_token: auth_info.refresh_token,
@@ -54,3 +55,4 @@ async fn login_and_update_config<'a>() -> Result<bool, CliError<'a>> {
 
     Ok(true)
 }
+

--- a/src/commands/pipeline/ci_status.rs
+++ b/src/commands/pipeline/ci_status.rs
@@ -38,7 +38,7 @@ pub async fn handle_ci_status<'a>(
     };
 
     let client = QueryClientBuilder::new()
-        .with_access_token(context.access_token.unwrap())
+        .with_access_token(context.id_token.unwrap())
         .build()?;
 
     let ci_status_resp = client

--- a/src/commands/pipeline/describe.rs
+++ b/src/commands/pipeline/describe.rs
@@ -15,7 +15,7 @@ pub async fn handle_describe<'a>(context: GlobalContext, name: &str) -> Result<b
 
     // Calling API ...
     let client = QueryClientBuilder::new()
-        .with_access_token(context.access_token.unwrap())
+        .with_access_token(context.id_token.unwrap())
         .build()?;
 
     let pipeline_resp = client

--- a/src/commands/pipeline/list.rs
+++ b/src/commands/pipeline/list.rs
@@ -28,7 +28,7 @@ pub async fn handle_list<'a>(context: GlobalContext) -> Result<bool, CliError<'a
 
     // Calling API ...
     let client = QueryClientBuilder::new()
-        .with_access_token(context.access_token.unwrap())
+        .with_access_token(context.id_token.unwrap())
         .build()?;
 
     let pipelines_data = client

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,7 @@ pub struct LogConfig {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthConfig {
     pub account: String,
+    pub id_token: String,
     pub access_token: String,
     pub expiry_time: String,
     pub refresh_token: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,7 +53,7 @@ impl<'a> CliError<'a> {
     pub fn suggestion(&self) -> Option<String> {
         match self {
             CliError::UnAuthenticated => Some(String::from(
-                "Run \"wukong login\" to authenticate with your okta account.",
+                "Your access token is invalid. Run \"wukong login\" to authenticate with your okta account.",
             )),
             CliError::UnInitialised => Some(String::from(
                 "Run \"wukong init\" to initialise Wukong's configuration.",

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ pub struct GlobalContext {
     application: Option<String>,
     account: Option<String>,
     access_token: Option<String>,
+    id_token: Option<String>,
 }
 
 #[tokio::main]
@@ -102,6 +103,7 @@ async fn run<'a>() -> Result<bool, CliError<'a>> {
                         match config.auth.as_mut() {
                             Some(existing_auth_config) => {
                                 existing_auth_config.refresh_token = new_tokens.refresh_token;
+                                existing_auth_config.id_token = new_tokens.id_token;
                                 existing_auth_config.access_token = new_tokens.access_token;
                                 existing_auth_config.expiry_time = new_tokens.expiry_time;
                             }
@@ -113,6 +115,7 @@ async fn run<'a>() -> Result<bool, CliError<'a>> {
                         config.save(&config_file).unwrap();
                         context.application = Some(config.core.application.clone());
                         context.account = Some(config.auth.as_ref().unwrap().account.clone());
+                        context.id_token = Some(config.auth.as_ref().unwrap().id_token.clone());
                         context.access_token =
                             Some(config.auth.as_ref().unwrap().access_token.clone());
                         existing_config = Some(config);
@@ -126,6 +129,7 @@ async fn run<'a>() -> Result<bool, CliError<'a>> {
                 context.application = Some(config.core.application.clone());
                 context.account = Some(config.auth.as_ref().unwrap().account.clone());
                 context.access_token = Some(config.auth.as_ref().unwrap().access_token.clone());
+                context.id_token = Some(config.auth.as_ref().unwrap().id_token.clone());
                 existing_config = Some(config.clone());
             }
         }


### PR DESCRIPTION
## Changelog
### New
- [x] use `id_token` for api calls