### PR TITLE
[Experimental] Add simple logger to Wukong CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-verbosity-flag"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e2b6c3dcdb73299f48ae05b294da14e2f560b3ed2c09e742269eb1b22af231"
+dependencies = [
+ "clap",
+ "log",
+]
+
+[[package]]
 name = "clap_complete"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,6 +3176,7 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "clap",
+ "clap-verbosity-flag",
  "clap_complete",
  "config",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ openssl = { version = "*", features = ["vendored"] }
 owo-colors = "3.5.0"
 chrono-humanize = "0.2.2"
 base64 = "0.13.0"
+clap-verbosity-flag = "2.0.0"
 
 [dev-dependencies]
 httpmock = "0.6.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ lto = true
 [dependencies]
 clap = { version = "4", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4" }
+clap-verbosity-flag = "2.0.0"
 dirs = "4.0"
 indicatif = "0.17.0"
 lazy_static = "1.4.0"
@@ -45,7 +46,6 @@ openssl = { version = "*", features = ["vendored"] }
 owo-colors = "3.5.0"
 chrono-humanize = "0.2.2"
 base64 = "0.13.0"
-clap-verbosity-flag = "2.0.0"
 
 [dev-dependencies]
 httpmock = "0.6.6"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Wukong CLI is a set of tools to manages Mindvalley DevOps resources. Its goa
 ## Installation
 
 ```bash
-brew tap mindvalley/wukong https://github.com/mindvalley/wukong-cli
+brew tap mindvalley/wukong
 brew install wukong
 ```
 
@@ -51,7 +51,7 @@ Then you should be able to check your rust version using:
 ```bash
 rustc --version
 # output
-# rustc 1.63.0 (4b91a6ea7 2022-08-08)
+# rustc 1.64.0 (a55dd71d5 2022-09-19)
 ```
 
 > **Note** > `rustc` is the Rust compiler

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -1,5 +1,6 @@
 use crate::commands::CommandGroup;
 use clap::Parser;
+use clap_verbosity_flag::Verbosity;
 
 /// A Swiss-army Knife CLI For Mindvalley Developers
 #[derive(Debug, Parser)]
@@ -12,6 +13,9 @@ pub struct ClapApp {
     /// If the flag is not used, then the CLI will use the default application name from the config.
     #[arg(long, short, global = true)]
     pub application: Option<String>,
+
+    #[clap(flatten)]
+    pub verbose: Verbosity,
 }
 
 #[cfg(test)]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,5 +1,12 @@
-use ansi_term::{ANSIString, Colour};
-use log::{Level, Metadata, Record};
+use log::{Level, LevelFilter, Metadata, Record};
+use owo_colors::{
+    colors::css::{DimGray, Gray},
+    OwoColorize,
+};
+
+pub struct Builder {
+    max_log_level: log::LevelFilter,
+}
 
 #[derive(Debug)]
 pub struct Logger;
@@ -14,15 +21,15 @@ impl log::Log for Logger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            let open = Colour::Fixed(243).paint("[");
+            let open = "[".fg::<DimGray>();
             let level = match record.level() {
-                log::Level::Error => Colour::Red.paint("ERROR"),
-                log::Level::Warn => Colour::Yellow.paint("WARN"),
-                log::Level::Info => Colour::Cyan.paint("INFO"),
-                log::Level::Debug => Colour::Blue.paint("DEBUG"),
-                log::Level::Trace => Colour::Fixed(245).paint("TRACE"),
+                Level::Error => "ERROR".red().to_string(),
+                Level::Warn => "WARN".yellow().to_string(),
+                Level::Info => "INFO".cyan().to_string(),
+                Level::Debug => "DEBUG".blue().to_string(),
+                Level::Trace => "TRACE".fg::<Gray>().to_string(),
             };
-            let close = Colour::Fixed(243).paint("]");
+            let close = "]".fg::<DimGray>();
 
             eprintln!(
                 "{}{} {}{} {}",
@@ -38,14 +45,21 @@ impl log::Log for Logger {
     fn flush(&self) {}
 }
 
-impl Logger {
+impl Builder {
     #[must_use = "You must call init() to begin logging"]
     pub fn new() -> Self {
-        Self
+        Self {
+            max_log_level: LevelFilter::Off,
+        }
+    }
+
+    pub fn with_max_level(mut self, max_log_level: LevelFilter) -> Self {
+        self.max_log_level = max_log_level;
+        self
     }
 
     pub fn init(self) {
-        log::set_max_level(log::LevelFilter::Trace);
-        log::set_logger(GLOBAL_LOGGER);
+        log::set_max_level(self.max_log_level);
+        log::set_logger(GLOBAL_LOGGER).expect("unable to init wukong-cli logger");
     }
 }


### PR DESCRIPTION
## What's Changed?
### New
- [x] Add a simple logger with verbosity flag using [clap-verbosity-flag](https://github.com/clap-rs/clap-verbosity-flag). The default log level is ERROR.
```bash
# silences output
wukong <command> -q
# show warnings
wukong <command> -v
# show info
wukong <command> -vv
# show debug
wukong <command> -vvv
# show trace
wukong <command> -vvvv
```
<img width="602" alt="Screenshot 2022-10-14 at 1 30 51 PM" src="https://user-images.githubusercontent.com/7545747/195769600-525590c9-6e81-40aa-b2b1-b76b4aeb8b00.png">
<img width="620" alt="Screenshot 2022-10-14 at 1 30 59 PM" src="https://user-images.githubusercontent.com/7545747/195769528-ddd3621f-afbe-466b-b855-896481f893f0.png">
<img width="604" alt="Screenshot 2022-10-14 at 1 31 07 PM" src="https://user-images.githubusercontent.com/7545747/195769530-71495ddb-83e7-4950-b839-88b7dda392bf.png">
<img width="597" alt="Screenshot 2022-10-14 at 1 31 16 PM" src="https://user-images.githubusercontent.com/7545747/195769535-38359b50-53b4-4264-961d-2c8ba9271800.png">
<img width="611" alt="Screenshot 2022-10-14 at 1 31 29 PM" src="https://user-images.githubusercontent.com/7545747/195769541-b65e51b6-04d9-4b49-85d9-5c3fb142a2ec.png">

I think the log should follow this
![z5Fim](https://user-images.githubusercontent.com/7545747/196343082-f06d6e6b-30b5-474d-9da6-65d9e748e501.png)

