### PR TITLE
PXP-389: Display better error message when cannot detect working folder

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,8 +16,8 @@ Ticket:
 
 <!-- Explain what is changed in this pull request -->
 
-<!-- ## Added -->
+<!-- ### Added -->
 
-<!-- ## Changed -->
+<!-- ### Changed -->
 
-<!-- ## Fixed -->
+<!-- ### Fixed -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+	Thanks for submitting a pull request!
+
+	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
+-->
+
+## Summary
+
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+
+<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
+
+Ticket:
+
+## What's Changed
+
+<!-- Explain what is changed in this pull request -->
+
+<!-- ## Added -->
+
+<!-- ## Changed -->
+
+<!-- ## Fixed -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 <!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
 
-<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
+<!-- Link any relevant issues or Jira ticket if necessary -->
 
 Ticket:
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use owo_colors::OwoColorize;
 use thiserror::Error as ThisError;
 
 #[derive(Debug, ThisError)]
@@ -81,13 +82,15 @@ impl<'a> CliError<'a> {
                 APIError::ResponseError { code, .. } if code == "application_not_found" => Some(
                     String::from("Please check your repo url. It's unrecognized by wukong."),
                 ),
-                APIError::ResponseError { code, .. } if code == "ci_status_application_not_found" => Some(
-                    r#"You can follow these steps to remedy this error:  
+                APIError::ResponseError { code, .. } if code == "ci_status_application_not_found" => Some(format!(
+        r#"
+        You can follow these steps to remedy this error:  
             1. Confirm that you're in the correct working folder.
-            2. If you're not, consider moving to the right location and run 'wukong pipeline ci-status' command again.
-        If none of the above steps work for you, please contact the following people on Slack for assistance 
-        :slack: @alex.tuan / :slack: @jk-gan / :slack: @Fadhil"#.to_string()
-                ),
+            2. If you're not, consider moving to the right location and run {} command again.
+        If none of the above steps work for you, please contact the following people on Slack for assistance: @alex.tuan / @jk-gan / @Fadhil
+        "#,
+        "wukong pipeline ci-status".yellow()
+                )),
                 APIError::UnAuthenticated => Some(
                     "Run \"wukong login\" to authenticate with your okta account.".to_string()
                 ),

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,7 +90,8 @@ impl<'a> CliError<'a> {
                     r#"You can follow these steps to remedy this error:  
             1. Confirm that you're in the correct working folder.
             2. If you're not, consider moving to the right location and run 'wukong pipeline ci-status' command again.
-        If none of the above steps work for you, please contact the following people on Slack for assistance :slack: @alex.tuan / :slack: @jk-gan / :slack: @Fadhil"#.to_string()
+        If none of the above steps work for you, please contact the following people on Slack for assistance 
+        :slack: @alex.tuan / :slack: @jk-gan / :slack: @Fadhil"#.to_string()
                 ),
                 _ => None,
             },

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,8 +26,6 @@ pub enum APIError {
     ResponseError { code: String, message: String },
     #[error("You are un-authenticated.")]
     UnAuthenticated,
-    #[error("Could not find the application associated with this Git repo.\n\tEither you're not in the correct working folder for your application, or there's a misconfiguration.")]
-    InvalidRepoUrl,
 }
 
 #[derive(Debug, ThisError)]
@@ -83,15 +81,15 @@ impl<'a> CliError<'a> {
                 APIError::ResponseError { code, .. } if code == "application_not_found" => Some(
                     String::from("Please check your repo url. It's unrecognized by wukong."),
                 ),
-                APIError::UnAuthenticated => Some(
-                    "Run \"wukong login\" to authenticate with your okta account.".to_string()
-                ),
-                APIError::InvalidRepoUrl => Some(
+                APIError::ResponseError { code, .. } if code == "ci_status_application_not_found" => Some(
                     r#"You can follow these steps to remedy this error:  
             1. Confirm that you're in the correct working folder.
             2. If you're not, consider moving to the right location and run 'wukong pipeline ci-status' command again.
         If none of the above steps work for you, please contact the following people on Slack for assistance 
         :slack: @alex.tuan / :slack: @jk-gan / :slack: @Fadhil"#.to_string()
+                ),
+                APIError::UnAuthenticated => Some(
+                    "Run \"wukong login\" to authenticate with your okta account.".to_string()
                 ),
                 _ => None,
             },

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,8 @@ pub enum APIError {
     ResponseError { code: String, message: String },
     #[error("You are un-authenticated.")]
     UnAuthenticated,
+    #[error("Could not find the application associated with this Git repo.\n\tEither you're not in the correct working folder for your application, or there's a misconfiguration.")]
+    InvalidRepoUrl,
 }
 
 #[derive(Debug, ThisError)]
@@ -83,6 +85,12 @@ impl<'a> CliError<'a> {
                 ),
                 APIError::UnAuthenticated => Some(
                     "Run \"wukong login\" to authenticate with your okta account.".to_string()
+                ),
+                APIError::InvalidRepoUrl => Some(
+                    r#"You can follow these steps to remedy this error:  
+            1. Confirm that you're in the correct working folder.
+            2. If you're not, consider moving to the right location and run 'wukong pipeline ci-status' command again.
+        If none of the above steps work for you, please contact the following people on Slack for assistance :slack: @alex.tuan / :slack: @jk-gan / :slack: @Fadhil"#.to_string()
                 ),
                 _ => None,
             },

--- a/src/graphql/pipeline.rs
+++ b/src/graphql/pipeline.rs
@@ -138,7 +138,7 @@ impl CiStatusQuery {
         let response = client
             .call_api::<Self>(variables, |resp, error| match error.message.as_str() {
                 "application_not_found" => Err(APIError::ResponseError { code: "ci_status_application_not_found".to_string(), message: 
-    "Could not find the application associated with this Git repo.\n\tEither you're not in the correct working folder for your application, or there's a misconfiguration.".to_string()
+    "Could not find the application associated with this Git repo.\n\t\t\tEither you're not in the correct working folder for your application, or there's a misconfiguration.".to_string()
                 }),
                 "no_builds_associated_with_this_branch" => Ok(resp),
                 _ => Err(APIError::ResponseError {

--- a/src/graphql/pipeline.rs
+++ b/src/graphql/pipeline.rs
@@ -137,10 +137,7 @@ impl CiStatusQuery {
 
         let response = client
             .call_api::<Self>(variables, |resp, error| match error.message.as_str() {
-                "application_not_found" => Err(APIError::ResponseError {
-                    code: error.message,
-                    message: format!("Application `{}` not found.", repo_url),
-                }),
+                "application_not_found" => Err(APIError::InvalidRepoUrl),
                 "no_builds_associated_with_this_branch" => Ok(resp),
                 _ => Err(APIError::ResponseError {
                     code: error.message.clone(),

--- a/src/graphql/pipeline.rs
+++ b/src/graphql/pipeline.rs
@@ -137,7 +137,9 @@ impl CiStatusQuery {
 
         let response = client
             .call_api::<Self>(variables, |resp, error| match error.message.as_str() {
-                "application_not_found" => Err(APIError::InvalidRepoUrl),
+                "application_not_found" => Err(APIError::ResponseError { code: "ci_status_application_not_found".to_string(), message: 
+    "Could not find the application associated with this Git repo.\n\tEither you're not in the correct working folder for your application, or there's a misconfiguration.".to_string()
+                }),
                 "no_builds_associated_with_this_branch" => Ok(resp),
                 _ => Err(APIError::ResponseError {
                     code: error.message.clone(),
@@ -601,10 +603,10 @@ mod test {
         match response.as_ref().unwrap_err() {
             APIError::ReqwestError(_) => panic!("it shouldn't returning ReqwestError"),
             APIError::ResponseError { code, message } => {
-                assert_eq!(code, "application_not_found");
+                assert_eq!(code, "ci_status_application_not_found");
                 assert_eq!(
                     message,
-                    "Application `http://invalid_repo_url.com` not found."
+                    "Could not find the application associated with this Git repo.\n\tEither you're not in the correct working folder for your application, or there's a misconfiguration."
                 );
             }
             APIError::UnAuthenticated => panic!("it shouldn't returning UnAuthenticated"),

--- a/src/graphql/pipeline.rs
+++ b/src/graphql/pipeline.rs
@@ -606,7 +606,7 @@ mod test {
                 assert_eq!(code, "ci_status_application_not_found");
                 assert_eq!(
                     message,
-                    "Could not find the application associated with this Git repo.\n\tEither you're not in the correct working folder for your application, or there's a misconfiguration."
+                    "Could not find the application associated with this Git repo.\n\t\t\tEither you're not in the correct working folder for your application, or there's a misconfiguration."
                 );
             }
             APIError::UnAuthenticated => panic!("it shouldn't returning UnAuthenticated"),


### PR DESCRIPTION
## Summary
The error message for `wukong pipeline ci-status` command is very confusing. This PR will display a more meaningful error message and suggestion.

Ticket: [PXP-389](https://mindvalley.atlassian.net/browse/PXP-389)

<img width="1545" alt="Screenshot 2022-10-17 at 2 23 48 PM" src="https://user-images.githubusercontent.com/7545747/196106397-bc601bd1-5c37-44dc-ba4f-5a23ee421800.png">


## What's Changed?
### Added 
- [x] add a PR template

### Changed
- [x] improve the error message for `wukong pipeline ci-status`