### PR TITLE
PXP-411: [CLI] Support render more than 1 commit in the build artifacts listing step

### DIFF
--- a/src/commands/deployment/execute.rs
+++ b/src/commands/deployment/execute.rs
@@ -20,11 +20,18 @@ struct TwoColumns {
 
 impl Display for TwoColumns {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (i, value) in self.right.iter().enumerate() {
-            if i == 0 {
-                writeln!(f, "{0: <13} {1}", self.left, value)?;
-            } else {
-                writeln!(f, "  {0: <13} {1}", "", value)?;
+        if self.right.is_empty() {
+            write!(f, "{0: <13}", self.left)?;
+        } else {
+            for (i, value) in self.right.iter().enumerate() {
+                if i == 0 {
+                    write!(f, "{0: <13} {1}", self.left, value)?;
+                } else {
+                    write!(f, "  {0: <13} {1}", "", value)?;
+                }
+                if i != (self.right.len() - 1) {
+                    writeln!(f)?;
+                }
             }
         }
 
@@ -157,6 +164,8 @@ pub async fn handle_execute<'a>(
             .data
             .unwrap()
             .cd_pipeline;
+
+        println!("{:?}", cd_pipeline_data);
 
         selected_build_number = match cd_pipeline_data {
             Some(cd_pipeline_data) => {

--- a/src/commands/deployment/execute.rs
+++ b/src/commands/deployment/execute.rs
@@ -121,7 +121,6 @@ pub async fn handle_execute<'a>(
         );
     } else {
         let version_selections = vec!["Green", "Blue"];
-        // let selected_version_index = Select::with_theme(&ColorfulTheme::default())
         let selected_version_index = Select::with_theme(&ColorfulTheme::default())
             .with_prompt("Step 2: Please choose the version you want to deploy")
             .default(0)
@@ -164,8 +163,6 @@ pub async fn handle_execute<'a>(
             .data
             .unwrap()
             .cd_pipeline;
-
-        println!("{:?}", cd_pipeline_data);
 
         selected_build_number = match cd_pipeline_data {
             Some(cd_pipeline_data) => {

--- a/src/graphql/changelog.rs
+++ b/src/graphql/changelog.rs
@@ -97,7 +97,7 @@ mod test {
         mock.assert();
         assert!(response.is_ok());
 
-        let changelogs = response.unwrap().data.unwrap().changelogs.unwrap();
+        let changelogs = response.unwrap().data.unwrap().changelogs;
         assert_eq!(changelogs.len(), 2);
     }
 
@@ -113,9 +113,7 @@ mod test {
 
         let api_resp = r#"
 {
-  "data": {
-    "changelogs": null
-  },
+  "data": null,
   "errors": [
     {
       "locations": [
@@ -168,9 +166,7 @@ mod test {
 
         let api_resp = r#"
 {
-  "data": {
-    "changelogs": null
-  },
+  "data": null,
   "errors": [
     {
       "locations": [

--- a/src/graphql/query/cd_pipeline.graphql
+++ b/src/graphql/query/cd_pipeline.graphql
@@ -12,14 +12,17 @@ String!) {
       buildDuration
       buildNumber
       buildUrl
-      commitAuthor
-      commitId
-      commitMsg
       name
       result
       timestamp
       totalDuration
       waitDuration
+      commits {
+        id
+        author
+        message
+        messageHeadline
+      }
     }
   }
 }

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -1093,12 +1093,16 @@
               "isDeprecated": false,
               "name": "commits",
               "type": {
-                "kind": "LIST",
+                "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Commit",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Commit",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -2001,12 +2005,16 @@
               "isDeprecated": false,
               "name": "changelogs",
               "type": {
-                "kind": "LIST",
+                "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Commit",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Commit",
+                    "ofType": null
+                  }
                 }
               }
             },

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -1099,9 +1099,13 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Commit",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Commit",
+                      "ofType": null
+                    }
                   }
                 }
               }
@@ -2011,9 +2015,13 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Commit",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Commit",
+                      "ofType": null
+                    }
                   }
                 }
               }

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -1091,6 +1091,22 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "commits",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Commit",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "name",
               "type": {
                 "kind": "NON_NULL",


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-411](https://mindvalley.atlassian.net/browse/PXP-411)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

### Changed
- [x] the build selections in `wukong deployment execute` command is now display in 2 columns format
<img width="984" alt="Screenshot 2022-10-27 at 3 48 14 PM" src="https://user-images.githubusercontent.com/7545747/198222826-9dc483eb-9e16-4ab3-9dac-3773295397c2.png">


<!-- ### Fixed -->

## Known Issue
(Not critical) The layout will be a bit off in narrow window or when the commit headline is too long
<img width="511" alt="Screenshot 2022-10-27 at 3 45 22 PM" src="https://user-images.githubusercontent.com/7545747/198222215-3559b5e9-718c-4ef9-b9d6-942428962813.png">

