### PR TITLE
PXP-416: [Wukong CLI] Allowing to override the api_url and okta_client_id in the config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,4 +120,4 @@ jobs:
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: build
-          args: --locked --release --target=${{ matrix.job.target }}
+          args: --locked --features prod --release --target=${{ matrix.job.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
-  API_URL: ${{ secrets.WUKONG_API_URL }}
-  OKTA_CLIENT_ID: ${{ secrets.OKTA_CLIENT_ID }}
 
 jobs:
   check-formatting-clippy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: build
-          args: --locked --release --target=${{ matrix.job.target }}
+          args: --locked --features prod --release --target=${{ matrix.job.target }}
 
       - name: Create tarball
         id: package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
-  API_URL: ${{ secrets.WUKONG_API_URL }}
-  OKTA_CLIENT_ID: ${{ secrets.OKTA_CLIENT_ID }}
 
 jobs:
   tag-name:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openidconnect"
@@ -3173,6 +3173,7 @@ dependencies = [
  "indicatif",
  "lazy_static",
  "log",
+ "once_cell",
  "openidconnect",
  "openssl",
  "owo-colors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "wukong"
 version = "0.0.3-alpha2"
 edition = "2021"
 
+[features]
+prod = []
+
 [profile.release]
 strip = true
 lto = true
@@ -46,6 +49,7 @@ chrono-humanize = "0.2.2"
 base64 = "0.13.0"
 console = "0.15.2"
 human-panic = "1.0.3"
+once_cell = "1.16.0"
 
 [dev-dependencies]
 httpmock = "0.6.6"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,0 @@
-[build.env]
-passthrough = [
-    "API_URL",
-    "OKTA_CLIENT_ID",
-]

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use crate::{
     error::{CliError, ConfigError},
 };
 use clap::Parser;
+use once_cell::sync::OnceCell;
 
 pub enum ConfigState {
     InitialisedButUnAuthenticated(Config),
@@ -16,10 +17,25 @@ pub struct App {
     pub cli: ClapApp,
 }
 
+#[derive(Debug)]
+pub struct AppState {
+    pub api_url: String,
+    pub okta_client_id: String,
+}
+
+pub static APP_STATE: OnceCell<AppState> = OnceCell::new();
+
 impl App {
     pub fn new(config_file: &'static str) -> Result<Self, CliError> {
         let config = match Config::load(config_file) {
             Ok(config) => {
+                APP_STATE
+                    .set(AppState {
+                        api_url: config.core.wukong_api_url.clone(),
+                        okta_client_id: config.core.okta_client_id.clone(),
+                    })
+                    .unwrap();
+
                 if config.auth.is_none() {
                     ConfigState::InitialisedButUnAuthenticated(config)
                 } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,6 +29,7 @@ impl App {
     pub fn new(config_file: &'static str) -> Result<Self, CliError> {
         let config = match Config::load(config_file) {
             Ok(config) => {
+                // get values from config file if the config is initialised
                 APP_STATE
                     .set(AppState {
                         api_url: config.core.wukong_api_url.clone(),
@@ -42,10 +43,26 @@ impl App {
                     ConfigState::InitialisedAndAuthenticated(config)
                 }
             }
-            Err(error) => match error {
-                CliError::ConfigError(ConfigError::NotFound { .. }) => ConfigState::Uninitialised,
-                _ => return Err(error),
-            },
+            Err(error) => {
+                // use default values if the config is not initialised
+                APP_STATE
+                    .set(AppState {
+                        #[cfg(all(feature = "prod"))]
+                        api_url: "https://wukong-api-proxy.mindvalley.dev/api".to_string(),
+                        #[cfg(not(feature = "prod"))]
+                        api_url: "http://localhost:4000/api".to_string(),
+
+                        okta_client_id: "0oakfxaegyAV5JDD5357".to_string(),
+                    })
+                    .unwrap();
+
+                match error {
+                    CliError::ConfigError(ConfigError::NotFound { .. }) => {
+                        ConfigState::Uninitialised
+                    }
+                    _ => return Err(error),
+                }
+            }
         };
 
         Ok(Self {

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -193,10 +193,7 @@ pub async fn login() -> Result<AuthInfo, CliError> {
 }
 
 pub async fn refresh_tokens(refresh_token: &RefreshToken) -> Result<TokenInfo, CliError> {
-    let okta_client_id = match APP_STATE.get() {
-        Some(app_state) => ClientId::new(app_state.okta_client_id.clone()),
-        None => ClientId::new("0oakfxaegyAV5JDD5357".to_string()),
-    };
+    let okta_client_id = ClientId::new(APP_STATE.get().unwrap().okta_client_id.clone());
 
     let issuer_url =
         IssuerUrl::new("https://mindvalley.okta.com".to_string()).expect("Invalid issuer URL");

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -37,10 +37,7 @@ pub struct TokenInfo {
 }
 
 pub async fn login() -> Result<AuthInfo, CliError> {
-    let okta_client_id = match APP_STATE.get() {
-        Some(app_state) => ClientId::new(app_state.okta_client_id.clone()),
-        None => ClientId::new("0oakfxaegyAV5JDD5357".to_string()),
-    };
+    let okta_client_id = ClientId::new(APP_STATE.get().unwrap().okta_client_id.clone());
 
     let issuer_url =
         IssuerUrl::new("https://mindvalley.okta.com".to_string()).expect("Invalid issuer URL");

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,4 +1,4 @@
-use crate::{error::CliError, OKTA_CLIENT_ID};
+use crate::{app::APP_STATE, error::CliError};
 use chrono::{Duration, Utc};
 use openidconnect::{
     core::{
@@ -37,7 +37,10 @@ pub struct TokenInfo {
 }
 
 pub async fn login() -> Result<AuthInfo, CliError> {
-    let okta_client_id = ClientId::new(OKTA_CLIENT_ID.to_string());
+    let okta_client_id = match APP_STATE.get() {
+        Some(app_state) => ClientId::new(app_state.okta_client_id.clone()),
+        None => ClientId::new("0oakfxaegyAV5JDD5357".to_string()),
+    };
 
     let issuer_url =
         IssuerUrl::new("https://mindvalley.okta.com".to_string()).expect("Invalid issuer URL");
@@ -193,7 +196,10 @@ pub async fn login() -> Result<AuthInfo, CliError> {
 }
 
 pub async fn refresh_tokens(refresh_token: &RefreshToken) -> Result<TokenInfo, CliError> {
-    let okta_client_id = ClientId::new(OKTA_CLIENT_ID.to_string());
+    let okta_client_id = match APP_STATE.get() {
+        Some(app_state) => ClientId::new(app_state.okta_client_id.clone()),
+        None => ClientId::new("0oakfxaegyAV5JDD5357".to_string()),
+    };
 
     let issuer_url =
         IssuerUrl::new("https://mindvalley.okta.com".to_string()).expect("Invalid issuer URL");

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -37,6 +37,8 @@ pub enum ConfigName {
     CollectTelemetry,
     EnableLog,
     LogDir,
+    WukongApiUrl,
+    OktaClientId,
 }
 
 impl Config {
@@ -91,6 +93,16 @@ impl Config {
                             config.save(config_file)?;
                             println!("Updated property [log/log_dir].");
                         }
+                        ConfigName::WukongApiUrl => {
+                            config.core.wukong_api_url = config_value.trim().to_string();
+                            config.save(config_file)?;
+                            println!("Updated property [core/wukong_api_url].");
+                        }
+                        ConfigName::OktaClientId => {
+                            config.core.okta_client_id = config_value.trim().to_string();
+                            config.save(config_file)?;
+                            println!("Updated property [core/okta_client_id].");
+                        }
                     },
                     Err(e) => {
                         cmd.error(ErrorKind::Io, e).exit();
@@ -110,6 +122,8 @@ impl Config {
                         }
                         ConfigName::EnableLog => println!("{}", config.log.enable),
                         ConfigName::LogDir => println!("{}", config.log.log_dir),
+                        ConfigName::WukongApiUrl => println!("{}", config.core.wukong_api_url),
+                        ConfigName::OktaClientId => println!("{}", config.core.okta_client_id),
                     },
                     Err(e) => {
                         cmd.error(ErrorKind::Io, e).exit();

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,8 @@ pub struct CoreConfig {
     /// The current application name
     pub application: String,
     pub collect_telemetry: bool,
+    pub wukong_api_url: String,
+    pub okta_client_id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -65,6 +67,16 @@ impl Default for Config {
             core: CoreConfig {
                 application: "".to_string(),
                 collect_telemetry: false,
+
+                #[cfg(not(feature = "prod"))]
+                wukong_api_url: "http://localhost:4000/api".to_string(),
+                #[cfg(not(feature = "prod"))]
+                okta_client_id: "0oakfxaegyAV5JDD5357".to_string(),
+
+                #[cfg(all(feature = "prod"))]
+                wukong_api_url: "https://wukong-api-proxy.mindvalley.dev/api".to_string(),
+                #[cfg(all(feature = "prod"))]
+                okta_client_id: "0oakfxaegyAV5JDD5357".to_string(),
             },
             log: LogConfig {
                 enable: true,

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,7 +73,7 @@ impl CliError {
                     "Run \"chmod +rw {path}\" to provide read and write permissions."
                 )),
                 ConfigError::BadTomlData(_) => Some(format!(
-                    "Check if your config.toml file is in valid TOML format.\n\tThe might happen when you accidentally modified the config file or there is a breaking change to the cli config in new version.\n\tYou may want to remove the config.toml file (\"rm {}\") and run \"wukong init\" to re-initialise configuration again.", CONFIG_FILE.as_ref().unwrap_or(&"/path/to/config.toml".to_string())
+                    "Check if your config.toml file is in valid TOML format.\n\tThis usually happen when the config file is accidentally modified or there is a breaking change to the cli config in the new version.\n\tYou may want to remove the config.toml file (\"rm {}\") and run \"wukong init\" to re-initialise configuration again.", CONFIG_FILE.as_ref().unwrap_or(&"/path/to/config.toml".to_string())
                 )),
                 _ => None,
             },

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,7 +62,7 @@ impl CliError {
                 "Your access token is invalid. Run \"wukong login\" to authenticate with your okta account.",
             )),
             CliError::UnInitialised => Some(String::from(
-                "Run \"wukong init\" to initialise Wukong's configuration.",
+                "Run \"wukong init\" to initialise Wukong's configuration before running other commands.",
             )),
             CliError::ConfigError(error) => match error {
                 ConfigError::NotFound { .. } => Some(String::from(

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,7 +73,7 @@ impl CliError {
                     "Run \"chmod +rw {path}\" to provide read and write permissions."
                 )),
                 ConfigError::BadTomlData(_) => Some(format!(
-                    "Check if your config.toml file is in valid TOML format. You may want to remove the config.toml file (\"rm {}\") and run \"wukong init\" to re-initialise configuration again.", CONFIG_FILE.as_ref().unwrap_or(&"/path/to/config.toml".to_string())
+                    "Check if your config.toml file is in valid TOML format.\n\tThe might happen when you accidentally modified the config file or there is a breaking change to the cli config in new version.\n\tYou may want to remove the config.toml file (\"rm {}\") and run \"wukong init\" to re-initialise configuration again.", CONFIG_FILE.as_ref().unwrap_or(&"/path/to/config.toml".to_string())
                 )),
                 _ => None,
             },

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,7 +73,7 @@ impl CliError {
                     "Run \"chmod +rw {path}\" to provide read and write permissions."
                 )),
                 ConfigError::BadTomlData(_) => Some(format!(
-                    "Check if your config.toml file is in valid TOML format. You may want to remove the config.toml file (\"rm {}\") and run \"wukong init\" to re-initialise configuration again.", CONFIG_FILE.as_ref().unwrap()
+                    "Check if your config.toml file is in valid TOML format. You may want to remove the config.toml file (\"rm {}\") and run \"wukong init\" to re-initialise configuration again.", CONFIG_FILE.as_ref().unwrap_or(&"/path/to/config.toml".to_string())
                 )),
                 _ => None,
             },

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use crate::CONFIG_FILE;
 use owo_colors::OwoColorize;
 use thiserror::Error as ThisError;
 
@@ -71,8 +72,8 @@ impl CliError {
                 ConfigError::PermissionDenied { path, .. } => Some(format!(
                     "Run \"chmod +rw {path}\" to provide read and write permissions."
                 )),
-                ConfigError::BadTomlData(_) => Some(String::from(
-                    "Check if your config.toml file is in valid TOML format. You may want to remove the config.toml file and run \"wukong init\" to re-initialise configuration again.",
+                ConfigError::BadTomlData(_) => Some(format!(
+                    "Check if your config.toml file is in valid TOML format. You may want to remove the config.toml file (\"rm {}\") and run \"wukong init\" to re-initialise configuration again.", CONFIG_FILE.as_ref().unwrap()
                 )),
                 _ => None,
             },

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -27,14 +27,8 @@ pub struct QueryClientBuilder {
 impl QueryClientBuilder {
     pub fn new() -> Self {
         let api_url = match APP_STATE.get() {
-            Some(app_state) => app_state.api_url.clone(),
-            None => {
-                if cfg!(feature = "prod") {
-                    "https://wukong-api-proxy.mindvalley.dev/api".to_string()
-                } else {
-                    "http://localhost:4000/api".to_string()
-                }
-            }
+            Some(state) => state.api_url.clone(),
+            None => "".to_string(),
         };
 
         Self {

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -15,7 +15,7 @@ use self::{
         CiStatusQuery, MultiBranchPipelineQuery, PipelineQuery, PipelinesQuery,
     },
 };
-use crate::{error::APIError, API_URL};
+use crate::{app::APP_STATE, error::APIError};
 use graphql_client::{reqwest::post_graphql, GraphQLQuery, Response};
 use reqwest::header;
 
@@ -26,9 +26,20 @@ pub struct QueryClientBuilder {
 
 impl QueryClientBuilder {
     pub fn new() -> Self {
+        let api_url = match APP_STATE.get() {
+            Some(app_state) => app_state.api_url.clone(),
+            None => {
+                if cfg!(feature = "prod") {
+                    "https://wukong-api-proxy.mindvalley.dev/api".to_string()
+                } else {
+                    "http://localhost:4000/api".to_string()
+                }
+            }
+        };
+
         Self {
             access_token: None,
-            api_url: API_URL.to_string(),
+            api_url,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,9 +43,6 @@ macro_rules! must_init_and_login {
     }};
 }
 
-static API_URL: &str = env!("API_URL");
-static OKTA_CLIENT_ID: &str = env!("OKTA_CLIENT_ID");
-
 #[derive(Default, Debug)]
 pub struct GlobalContext {
     application: Option<String>,

--- a/src/output/error.rs
+++ b/src/output/error.rs
@@ -84,7 +84,7 @@ mod test {
             format!("{}", error_output),
             error_output_with_suggestion(
                 "You are un-initialised.",
-                "Run \"wukong init\" to initialise Wukong's configuration."
+                "Run \"wukong init\" to initialise Wukong's configuration before running other commands."
             )
         );
     }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-416](https://mindvalley.atlassian.net/browse/PXP-416)

## What's Changed

<!-- Explain what is changed in this pull request -->

### Added
- [x] **BREAKING**: add `wukong_api_url` and `okta_client_id` into config file
<img width="615" alt="Screenshot 2022-11-03 at 4 22 54 PM" src="https://user-images.githubusercontent.com/7545747/199674985-64afdf2e-7e40-4d9e-a6f7-c4a059fc341b.png">

User will get the message if they updated to this version but using the old `config.toml` values:
<img width="1754" alt="Screenshot 2022-11-03 at 5 03 48 PM" src="https://user-images.githubusercontent.com/7545747/199682182-6c4354cc-7e0e-4768-99fd-54fa2294f5ab.png">

They have to remove the existing `config.toml` file and run `wukong init` to re-initialise the config then it should be all good.

- [x] add a way to get and set `wukong_api_url` and `okta_client_id` by using `wukong config get/set wukong-api-url` and `wukong config get/set okta-client-id` respectively
<img width="1515" alt="Screenshot 2022-11-03 at 5 18 05 PM" src="https://user-images.githubusercontent.com/7545747/199684710-004b76ae-393b-436c-9a6e-f277af9f84a3.png">

<img width="1519" alt="Screenshot 2022-11-03 at 5 17 33 PM" src="https://user-images.githubusercontent.com/7545747/199684592-96671e0b-fb58-4f2c-8b15-a742403e0102.png">



### Changed
- [x] add a new feature flag `prod` to set the prod values as default values to the config file, it is used in production build in github actions
    - `cargo run --features prod -- command` will use the prod values

### Fixed
- [x] fix a bug when the user re-init wukong-cli using `wukong init` command, the config file is not creating a new config
