### PR TITLE
PXP-424: [CLI] Use Short Commit Hash rather than full commit hash

### DIFF
--- a/src/commands/deployment/list.rs
+++ b/src/commands/deployment/list.rs
@@ -96,7 +96,9 @@ pub async fn handle_list(context: GlobalContext) -> Result<bool, CliError> {
             name: raw_cd_pipeline.name,
             version: raw_cd_pipeline.version,
             enabled: raw_cd_pipeline.enabled,
-            deployed_ref: raw_cd_pipeline.deployed_ref,
+            deployed_ref: raw_cd_pipeline
+                .deployed_ref
+                .map(|deployed_ref| deployed_ref[..7].to_string()),
             last_deployed_at: raw_cd_pipeline.last_deployment,
             status: raw_cd_pipeline.status,
         };


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-424](https://mindvalley.atlassian.net/browse/PXP-424)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

### Changed
- [x] display short hash in `wukong deployment list`
<img width="1670" alt="Screenshot 2022-11-07 at 12 38 47 PM" src="https://user-images.githubusercontent.com/7545747/200228349-02863957-c723-441e-a5b5-db2e347b55af.png">


<!-- ### Fixed -->
