### PR TITLE
PXP-417: [Wukong CLI] Don't display selection if it's not available for an application

### DIFF
--- a/src/commands/deployment/execute.rs
+++ b/src/commands/deployment/execute.rs
@@ -1,6 +1,9 @@
 use super::{DeploymentNamespace, DeploymentVersion};
 use crate::{
-    error::CliError, graphql::QueryClientBuilder, loader::new_spinner_progress_bar, GlobalContext,
+    error::{CliError, DeploymentError},
+    graphql::QueryClientBuilder,
+    loader::new_spinner_progress_bar,
+    GlobalContext,
 };
 use console::Term;
 use dialoguer::{theme::ColorfulTheme, Confirm, Select};
@@ -84,6 +87,9 @@ pub async fn handle_execute(
     let current_application = context.application.unwrap();
     println!("Current application: {}", current_application.green());
 
+    let progress_bar = new_spinner_progress_bar();
+    progress_bar.set_message("Checking available CD pipelines ...");
+
     // Calling API ...
     let client = QueryClientBuilder::new()
         .with_access_token(context.id_token.unwrap())
@@ -113,6 +119,9 @@ pub async fn handle_execute(
         .find_map(|pipeline| pipeline.version.contains("blue").then_some(pipeline))
         .is_some();
 
+    progress_bar.finish_and_clear();
+
+    // if there is no Prod and Staging, return message, end the session
     if !has_prod_namespace && !has_staging_namespace {
         println!("This application is not configured with any CD Pipelines yet, cannot performing any deployment. Please configure at least 1 CD Pipeline before making a deployment");
         return Ok(false);
@@ -124,6 +133,33 @@ pub async fn handle_execute(
 
     // if user provides namespace using --namespace flag
     if let Some(namespace) = namespace {
+        match namespace {
+            // if user set `prod` in --namespace flag but there is no `prod` namespace for the
+            // application
+            DeploymentNamespace::Prod => {
+                if !has_prod_namespace {
+                    return Err(CliError::DeploymentError(
+                        DeploymentError::NamespaceNotAvailable {
+                            namespace: "prod".to_string(),
+                            application: current_application.clone(),
+                        },
+                    ));
+                }
+            }
+            // if user set `staging` in --namespace flag but there is no `staging` namespace for the
+            // application
+            DeploymentNamespace::Staging => {
+                if !has_staging_namespace {
+                    return Err(CliError::DeploymentError(
+                        DeploymentError::NamespaceNotAvailable {
+                            namespace: "staging".to_string(),
+                            application: current_application.clone(),
+                        },
+                    ));
+                }
+            }
+        };
+
         selected_namespace = namespace.to_string();
         println!(
             "{} {} `{}` {}\n",
@@ -156,6 +192,32 @@ pub async fn handle_execute(
 
     // if user provides version using --version flag
     if let Some(version) = version {
+        match version {
+            // if user set `blue` in --version flag but there is no `blue` version for the
+            // application
+            DeploymentVersion::Blue => {
+                if !has_blue_version {
+                    return Err(CliError::DeploymentError(
+                        DeploymentError::VersionNotAvailable {
+                            version: "blue".to_string(),
+                            application: current_application.clone(),
+                        },
+                    ));
+                }
+            }
+            // if user set `green` in --version flag but there is no `green` version for the
+            // application
+            DeploymentVersion::Green => {
+                if !has_green_version {
+                    return Err(CliError::DeploymentError(
+                        DeploymentError::VersionNotAvailable {
+                            version: "green".to_string(),
+                            application: current_application.clone(),
+                        },
+                    ));
+                }
+            }
+        };
         selected_version = version.to_string();
         println!(
             "{} {} `{}` {}\n",

--- a/src/commands/deployment/execute.rs
+++ b/src/commands/deployment/execute.rs
@@ -104,12 +104,10 @@ pub async fn handle_execute(
 
     let has_prod_namespace = cd_pipelines_resp
         .iter()
-        .find(|pipeline| pipeline.environment == "prod")
-        .is_some();
+        .any(|pipeline| pipeline.environment == "prod");
     let has_staging_namespace = cd_pipelines_resp
         .iter()
-        .find(|pipeline| pipeline.environment == "staging")
-        .is_some();
+        .any(|pipeline| pipeline.environment == "staging");
 
     progress_bar.finish_and_clear();
 
@@ -187,13 +185,11 @@ pub async fn handle_execute(
     let has_green_version = cd_pipelines_resp
         .iter()
         .filter(|pipeline| pipeline.environment == selected_namespace.to_lowercase())
-        .find(|pipeline| pipeline.version == "green")
-        .is_some();
+        .any(|pipeline| pipeline.version == "green");
     let has_blue_version = cd_pipelines_resp
         .iter()
         .filter(|pipeline| pipeline.environment == selected_namespace.to_lowercase())
-        .find(|pipeline| pipeline.version == "blue")
-        .is_some();
+        .any(|pipeline| pipeline.version == "blue");
 
     // if user provides version using --version flag
     if let Some(version) = version {

--- a/src/commands/deployment/execute.rs
+++ b/src/commands/deployment/execute.rs
@@ -113,10 +113,10 @@ pub async fn handle_execute(
         .find_map(|pipeline| pipeline.version.contains("blue").then_some(pipeline))
         .is_some();
 
-    // if !has_prod_namespace && !has_staging_namespace {
-    //     println!("This application is not configured with any CD Pipelines yet, cannot performing any deployment. Please configure at least 1 CD Pipeline before making a deployment");
-    //     return Ok(false);
-    // }
+    if !has_prod_namespace && !has_staging_namespace {
+        println!("This application is not configured with any CD Pipelines yet, cannot performing any deployment. Please configure at least 1 CD Pipeline before making a deployment");
+        return Ok(false);
+    }
 
     let selected_namespace: String;
     let selected_version: String;

--- a/src/commands/deployment/execute.rs
+++ b/src/commands/deployment/execute.rs
@@ -104,11 +104,11 @@ pub async fn handle_execute(
 
     let has_prod_namespace = cd_pipelines_resp
         .iter()
-        .find_map(|pipeline| pipeline.environment.contains("prod").then_some(pipeline))
+        .find(|pipeline| pipeline.environment == "prod")
         .is_some();
     let has_staging_namespace = cd_pipelines_resp
         .iter()
-        .find_map(|pipeline| pipeline.environment.contains("staging").then_some(pipeline))
+        .find(|pipeline| pipeline.environment == "staging")
         .is_some();
 
     progress_bar.finish_and_clear();
@@ -187,12 +187,12 @@ pub async fn handle_execute(
     let has_green_version = cd_pipelines_resp
         .iter()
         .filter(|pipeline| pipeline.environment == selected_namespace.to_lowercase())
-        .find_map(|pipeline| pipeline.version.contains("green").then_some(pipeline))
+        .find(|pipeline| pipeline.version == "green")
         .is_some();
     let has_blue_version = cd_pipelines_resp
         .iter()
         .filter(|pipeline| pipeline.environment == selected_namespace.to_lowercase())
-        .find_map(|pipeline| pipeline.version.contains("blue").then_some(pipeline))
+        .find(|pipeline| pipeline.version == "blue")
         .is_some();
 
     // if user provides version using --version flag

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,8 @@ pub enum CliError {
     UnInitialised,
     #[error("{message}")]
     AuthError { message: &'static str },
+    #[error(transparent)]
+    DeploymentError(#[from] DeploymentError),
 }
 
 #[derive(Debug, ThisError)]
@@ -52,6 +54,20 @@ pub enum ConfigError {
     BadTomlData(#[source] toml::de::Error),
     #[error("Failed to serialize configuration data into TOML.")]
     SerializeTomlError(#[source] toml::ser::Error),
+}
+
+#[derive(Debug, ThisError)]
+pub enum DeploymentError {
+    #[error("\"{namespace}\" namespace is not available in \"{application}\" application.")]
+    NamespaceNotAvailable {
+        namespace: String,
+        application: String,
+    },
+    #[error("\"{version}\" version is not available in \"{application}\" application.")]
+    VersionNotAvailable {
+        version: String,
+        application: String,
+    },
 }
 
 impl CliError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,8 +63,9 @@ pub enum DeploymentError {
         namespace: String,
         application: String,
     },
-    #[error("\"{version}\" version is not available in \"{application}\" application.")]
+    #[error("\"{version}\" version is not available in \"{application}\" application under \"{namespace}\" namespace.")]
     VersionNotAvailable {
+        namespace: String,
         version: String,
         application: String,
     },


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The namespace selections always show `Prod` and `Staging`, and the version selections always show `Blue` and `Green` even if the current application doesn't have that namespace/version. Now the selections will be based on the API result.

If the user is using `--namespace` or `--version` flag but the value provided is not available for the current application, the cli will return `DeploymentError`.
 
<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-417](https://mindvalley.atlassian.net/browse/PXP-417)

## What's Changed

<!-- Explain what is changed in this pull request -->

### Added
- [x] Add `DeploymentError`
<img width="1512" alt="Screenshot 2022-11-09 at 2 40 17 PM" src="https://user-images.githubusercontent.com/7545747/200757672-2185573f-79ab-4de8-a11d-2fa41f049e3b.png">

### Changed
- [x] The namespace and version selections now depend on the API result during `wukong deployment execute`
<img width="1490" alt="Screenshot 2022-11-09 at 2 42 05 PM" src="https://user-images.githubusercontent.com/7545747/200757954-8cc8806f-1a49-4480-ab53-188707e0beae.png">
<img width="1490" alt="Screenshot 2022-11-09 at 2 42 08 PM" src="https://user-images.githubusercontent.com/7545747/200757984-c6c50050-3cf1-45da-bf3d-eecffae917f1.png">


<!-- ### Fixed -->
