### PR TITLE
PXP-436: [Wukong CLI] Display message to tell user that there are a deployment with same arguments is running

### DIFF
--- a/src/graphql/deployment.rs
+++ b/src/graphql/deployment.rs
@@ -107,8 +107,12 @@ impl ExecuteCdPipeline {
                     code: error.message,
                     message: format!("Application `{}` not found.", application),
                 }),
+                "deploy_for_this_build_is_currently_running" => Err(APIError::ResponseError {
+                    code: error.message, 
+                    message: "Cannot submit this deployment request, since there is another running deployment with the same arguments is running on Spinnaker.\nYou can wait a few minutes and submit the deployment again.".to_string()
+                }),
                 _ => Err(APIError::ResponseError {
-                    code: error.message.clone(),
+                        code: error.message.clone(),
                     message: format!("{}", error),
                 }),
             })

--- a/src/graphql/deployment.rs
+++ b/src/graphql/deployment.rs
@@ -108,7 +108,7 @@ impl ExecuteCdPipeline {
                     message: format!("Application `{}` not found.", application),
                 }),
                 "deploy_for_this_build_is_currently_running" => Err(APIError::ResponseError {
-                    code: error.message, 
+                    code: error.message,
                     message: "Cannot submit this deployment request, since there is another running deployment with the same arguments is running on Spinnaker.\nYou can wait a few minutes and submit the deployment again.".to_string()
                 }),
                 _ => Err(APIError::ResponseError {

--- a/src/graphql/deployment.rs
+++ b/src/graphql/deployment.rs
@@ -112,7 +112,7 @@ impl ExecuteCdPipeline {
                     message: "Cannot submit this deployment request, since there is another running deployment with the same arguments is running on Spinnaker.\nYou can wait a few minutes and submit the deployment again.".to_string()
                 }),
                 _ => Err(APIError::ResponseError {
-                        code: error.message.clone(),
+                    code: error.message.clone(),
                     message: format!("{}", error),
                 }),
             })


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-436](https://mindvalley.atlassian.net/browse/PXP-436)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

### Changed
- [x] handle `deploy_for_this_build_is_currently_running` when executing deployment

<!-- ### Fixed -->
 
