### PR TITLE
PXP-426: [CLI] Show which build artifact is the current deployed one when selecting artifact

### DIFF
--- a/src/graphql/query/cd_pipeline.graphql
+++ b/src/graphql/query/cd_pipeline.graphql
@@ -2,6 +2,7 @@ query CdPipelineQuery($application: String!, $namespace: String!, $version:
 String!) {
   cdPipeline(application: $application, namespace: $namespace, version: $version) {
     deployedRef
+    buildArtifact
     environment
     enabled
     lastDeployment
@@ -11,6 +12,7 @@ String!) {
     jenkinsBuilds {
       buildDuration
       buildNumber
+      buildBranch
       buildUrl
       name
       result

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -1011,6 +1011,22 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "buildBranch",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "buildDuration",
               "type": {
                 "kind": "SCALAR",
@@ -1193,6 +1209,18 @@
           "description": null,
           "enumValues": null,
           "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "buildArtifact",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
             {
               "args": [],
               "deprecationReason": null,


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-426](https://mindvalley.atlassian.net/browse/PXP-426)

* This is using this [PR](https://github.com/mindvalley/wukong-api-proxy/pull/47) as backend to get the `buildBranch` value

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->
- [x] show the current build on the selection in `wukong deployment execute` command
    - if the build selection list contains the current build, it will display in 3 columns layout
      <img width="1872" alt="Screenshot 2022-12-06 at 4 17 13 PM" src="https://user-images.githubusercontent.com/7545747/205861697-bbe1843b-13fb-427b-88f9-690311016118.png">
    - if the current `build_artifact` is not in `{branch}-build-{build_number}` pattern, or the build selection list doesn't contain the current build, it will display in 2 columns layout
      <img width="1872" alt="Screenshot 2022-12-06 at 4 37 49 PM" src="https://user-images.githubusercontent.com/7545747/205862256-1ab24235-80ac-453b-8844-3b8852fa8aaa.png">


<!-- ### Changed -->

<!-- ### Fixed -->
