### PR TITLE
PXP-494: [Wukong CLI] Improving the debug log for Okta refresh token flow

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,5 +1,6 @@
 use crate::error::CliError;
 use chrono::{Duration, Utc};
+use log::debug;
 use openidconnect::{
     core::{
         CoreClient, CoreIdTokenClaims, CoreIdTokenVerifier, CoreProviderMetadata, CoreResponseType,
@@ -226,8 +227,11 @@ impl Auth {
             .exchange_refresh_token(refresh_token)
             .request_async(async_http_client)
             .await
-            .map_err(|_err| CliError::AuthError {
-                message: "Failed to contact token endpoint",
+            .map_err(|err| {
+                debug!("Error when refreshing token: {}", err);
+                CliError::AuthError {
+                    message: "Failed to contact token endpoint",
+                }
             })?;
 
         let id_token = token_response


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Add a debug log when refreshing token failed. This should allow us to know the exact error when the error happen again.

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-494](https://mindvalley.atlassian.net/browse/PXP-494)

## What's Changed

<!-- Explain what is changed in this pull request -->

### Added
- [x] add a debug log when refresh token error

<!-- ### Changed -->

<!-- ### Fixed -->


[PXP-494]: https://mindvalley.atlassian.net/browse/PXP-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ