### PR TITLE
fix: remove unused step for macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,6 @@ jobs:
           target: ${{ matrix.job.target }}
           components: rustfmt, clippy
 
-      - name: Install macOS packages
-        uses: mbround18/setup-osxcross@v1
-        if: contains(matrix.job.target, 'apple-darwin')
-        with:
-          osx-version: "12.3"
-
       - name: Install Linux packages
         if: contains(matrix.job.target, 'linux')
         shell: bash


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket:

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

### Fixed
- [x] remove the "Install macOS packages" step from `release.yml` because that is only applicable if we want to build macos binary in linux
