### PR TITLE
PXP-489 retry request on query timeout

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -35,8 +35,6 @@ pub enum APIError {
     ChangelogComparingSameBuild,
     #[error("Request to {domain} timed out.")]
     Timeout { domain: String },
-    #[error("Domain Error")]
-    DomainError,
 }
 
 #[derive(Debug, ThisError)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,10 +21,6 @@ pub enum CliError {
     AuthError { message: &'static str },
     #[error(transparent)]
     DeploymentError(#[from] DeploymentError),
-    #[error("Request to {domain} timed out.")]
-    Timeout { domain: String },
-    #[error("Domain Error")]
-    DomainError,
 }
 
 #[derive(Debug, ThisError)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,10 @@ pub enum CliError {
     AuthError { message: &'static str },
     #[error(transparent)]
     DeploymentError(#[from] DeploymentError),
+    #[error("Timeout Error")]
+    Timeout,
+    #[error("Domain Error")]
+    DomainError,
 }
 
 #[derive(Debug, ThisError)]
@@ -33,6 +37,10 @@ pub enum APIError {
     UnAuthenticated,
     #[error("The selected build number is the same as the current deployed version. So there is no changelog.")]
     ChangelogComparingSameBuild,
+    #[error("Timeout Error")]
+    Timeout,
+    #[error("Domain Error")]
+    DomainError,
 }
 
 #[derive(Debug, ThisError)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,8 +21,8 @@ pub enum CliError {
     AuthError { message: &'static str },
     #[error(transparent)]
     DeploymentError(#[from] DeploymentError),
-    #[error("Timeout Error")]
-    Timeout,
+    #[error("Request to {domain} timed out.")]
+    Timeout { domain: String },
     #[error("Domain Error")]
     DomainError,
 }
@@ -37,8 +37,8 @@ pub enum APIError {
     UnAuthenticated,
     #[error("The selected build number is the same as the current deployed version. So there is no changelog.")]
     ChangelogComparingSameBuild,
-    #[error("Timeout Error")]
-    Timeout,
+    #[error("Request to {domain} timed out.")]
+    Timeout { domain: String },
     #[error("Domain Error")]
     DomainError,
 }

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -282,8 +282,6 @@ pub fn check_retry_and_auth_error(error: &graphql_client::Error) -> Option<APIEr
         return Some(APIError::Timeout {
             domain: domain.to_string(),
         });
-    } else if error.message.contains("domain") {
-        return Some(APIError::DomainError);
     } else {
         return None;
     }

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -104,7 +104,6 @@ impl QueryClient {
 
         let response: Result<Response<Q::ResponseData>, APIError> =
             self.retry_request::<Q>(body, handler).await;
-        debug!("response: {:#?}", response);
 
         response
     }

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -278,6 +278,7 @@ pub fn check_retry_and_auth_error(error: &graphql_client::Error) -> Option<APIEr
     if error.message == "Unauthenticated" {
         Some(APIError::UnAuthenticated)
     } else if error.message.contains("request_timeout") {
+        // The Wukong API returns a message like "{{domain}_request_timeout}", so we need to extract the domain
         let domain = error.message.split('_').next().unwrap();
         return Some(APIError::Timeout {
             domain: domain.to_string(),

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -100,11 +100,11 @@ impl QueryClient {
         let body = Q::build_query(variables);
 
         debug!("url: {:?}", &self.api_url);
-        debug!("GraphQL query: \n{}", body.query);
+        debug!("query: \n{}", body.query);
 
         let response: Result<Response<Q::ResponseData>, APIError> =
             self.retry_request::<Q>(body, handler).await;
-        debug!("GraphQL response: {:#?}", response);
+        debug!("response: {:#?}", response);
 
         response
     }
@@ -125,12 +125,12 @@ impl QueryClient {
         let mut retry_count = 0;
         let request = self.inner().post(&self.api_url).json(&body);
 
-        debug!("GraphQL equest: {:#?}", request);
+        debug!("request: {:#?}", request);
 
         let mut response: Response<<Q as GraphQLQuery>::ResponseData> =
             request.send().await?.json().await?;
 
-        debug!("GraphQL response: {:#?}", response);
+        debug!("response: {:#?}", response);
 
         // We use <= 3 so it does one extra loop where the last response is checked
         // in order to return an APIError::Timeout if it was a timeout error in the
@@ -159,7 +159,7 @@ impl QueryClient {
 
                         response = request.send().await?.json().await?;
 
-                        debug!("GraphQL response: {:#?}", response);
+                        debug!("response: {:#?}", response);
                     }
                     _ => return handler(response, first_error),
                 }

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -276,11 +276,11 @@ impl QueryClient {
 
 pub fn check_retry_and_auth_error(error: &graphql_client::Error) -> Option<APIError> {
     if error.message == "Unauthenticated" {
-        return Some(APIError::UnAuthenticated);
+        Some(APIError::UnAuthenticated)
     } else if error.message.contains("request_timeout") {
-        let domain = error.message.split("_").next().unwrap();
+        let domain = error.message.split('_').next().unwrap();
         return Some(APIError::Timeout {
-            domain: format!("{domain}"),
+            domain: domain.to_string(),
         });
     } else if error.message.contains("domain") {
         return Some(APIError::DomainError);

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -124,6 +124,9 @@ impl QueryClient {
     {
         let mut retry_count = 0;
         let request = self.inner().post(&self.api_url).json(&body);
+
+        debug!("GraphQL equest: {:#?}", request);
+
         let mut response: Response<<Q as GraphQLQuery>::ResponseData> =
             request.send().await?.json().await?;
 
@@ -147,13 +150,12 @@ impl QueryClient {
                             "... request to {domain} timed out, retrying the request {}/3",
                             retry_count
                         );
-                        debug!("request to {domain} timed out. Retry {retry_count}/3");
 
                         thread::sleep(time::Duration::from_secs(5));
 
                         let request = self.inner().post(&self.api_url).json(&body);
 
-                        debug!("request: {:?}", request);
+                        debug!("request: {:#?}", request);
 
                         response = request.send().await?.json().await?;
 

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -277,8 +277,8 @@ impl QueryClient {
     }
 }
 
-// Check if the error is a retryable error or an authentication error. If the code
-// is a retryable error, we rerun the request up to 3 times and return the result.
+// Check if the error is a timeout error or an authentication error.
+// For Timeout errors, we get the domain and return it as part of the Timeout error.
 fn check_retry_and_auth_error(error: &graphql_client::Error) -> Option<APIError> {
     if error.message == "Unauthenticated" {
         Some(APIError::UnAuthenticated)


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

In this PR, we introduce a `retry` mechanism for requests that `timeout`.  If a request to our third-party APIs timeout, the request is retried up to 3 times (waiting 5 seconds after each attempt).

xtTicket: https://mindvalley.atlassian.net/browse/PXP-489

## What's Changed

<!-- ### Changed -->
- [x] `QueryClient.call_api` to retry requests if they timeout
- [x] Retry maximum of 3 times
- [x] Backoff 5 seconds for each retry

<img width="878" alt="Screenshot 2023-03-21 at 3 51 58 PM" src="https://user-images.githubusercontent.com/170094/226546450-7c8e00f9-fc78-43d4-9e02-304936b0e2f0.png">
<img width="1040" alt="Screenshot 2023-03-21 at 3 29 12 PM" src="https://user-images.githubusercontent.com/170094/226541875-17531de6-00ab-49b7-b19d-35cb736ddc08.png">

