### PR TITLE
PXP-475: [Wukong CLI] Refactor auth logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,17 +243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-std"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3992,7 +3981,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_fs",
- "async-recursion",
  "base64 0.21.0",
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ miette = { version = "5.5.0", features = ["fancy"] }
 ignore = "0.4.20"
 rayon = "1.7.0"
 tree-sitter = "0.20.9"
-async-recursion = "1.0.2"
 
 [dev-dependencies]
 httpmock = "0.6.7"
@@ -85,7 +84,4 @@ git2 = "0.16.1"
 git = "https://github.com/elixir-lang/tree-sitter-elixir"
 
 [profile.dev.package.insta]
-opt-level = 3
-
-[profile.dev.package.similar]
 opt-level = 3

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,7 +67,7 @@ pub struct CoreConfig {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct VaultConfig {
-    pub api_key: String,
+    pub api_token: String,
 }
 
 pub struct ConfigWithPath {

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,9 +39,9 @@ pub enum VaultError {
     Io(#[from] ::std::io::Error),
     #[error("Secret not found.")]
     SecretNotFound,
-    #[error("API key not found.")]
+    #[error("API token ot found.")]
     ApiTokenNotFound,
-    #[error("Invalid API key.")]
+    #[error("Invalid API token.")]
     ApiTokenInvalid,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,9 +40,9 @@ pub enum VaultError {
     #[error("Secret not found.")]
     SecretNotFound,
     #[error("API key not found.")]
-    ApiKeyNotFound,
+    ApiTokenNotFound,
     #[error("Invalid API key.")]
-    ApiKeyInvalid,
+    ApiTokenInvalid,
 }
 
 #[derive(Debug, ThisError)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,9 +40,9 @@ pub enum VaultError {
     #[error("Secret not found.")]
     SecretNotFound,
     #[error("API key not found.")]
-    ApiTokenNotFound,
+    ApiKeyNotFound,
     #[error("Invalid API key.")]
-    ApiTokenInvalid,
+    ApiKeyInvalid,
 }
 
 #[derive(Debug, ThisError)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,7 +39,7 @@ pub enum VaultError {
     Io(#[from] ::std::io::Error),
     #[error("Secret not found.")]
     SecretNotFound,
-    #[error("API token ot found.")]
+    #[error("API token not found.")]
     ApiTokenNotFound,
     #[error("Invalid API token.")]
     ApiTokenInvalid,

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,10 @@ pub enum VaultError {
     Io(#[from] ::std::io::Error),
     #[error("Secret not found.")]
     SecretNotFound,
+    #[error("API key not found.")]
+    ApiTokenNotFound,
+    #[error("Invalid API key.")]
+    ApiTokenInvalid,
 }
 
 #[derive(Debug, ThisError)]

--- a/src/services/vault/mod.rs
+++ b/src/services/vault/mod.rs
@@ -41,13 +41,13 @@ impl Vault {
     pub async fn get_token_or_login(&self) -> Result<String, VaultError> {
         let mut token = match self.get_token().await {
             Ok(token) => token,
-            Err(VaultError::ApiTokenNotFound) => self.handle_login().await?,
+            Err(VaultError::ApiKeyNotFound) => self.handle_login().await?,
             Err(err) => return Err(err),
         };
 
         match self.is_valid_token(&token).await {
             Ok(_) => Ok(token),
-            Err(VaultError::ApiTokenInvalid) => {
+            Err(VaultError::ApiKeyInvalid) => {
                 token = self.handle_login().await?;
                 Ok(token)
             }
@@ -166,7 +166,7 @@ impl Vault {
         let api_key = match &config_with_path.config.vault {
             Some(vault_config) => vault_config.api_key.clone(),
             None => {
-                return Err(VaultError::ApiTokenNotFound);
+                return Err(VaultError::ApiKeyNotFound);
             }
         };
 
@@ -197,7 +197,7 @@ impl Vault {
 
         match status {
             StatusCode::NOT_FOUND => Err(VaultError::SecretNotFound),
-            StatusCode::FORBIDDEN => Err(VaultError::ApiTokenInvalid),
+            StatusCode::FORBIDDEN => Err(VaultError::ApiKeyInvalid),
             StatusCode::BAD_REQUEST => {
                 if message.contains("Okta auth failed") {
                     Err(VaultError::AuthenticationFailed)

--- a/src/services/vault/mod.rs
+++ b/src/services/vault/mod.rs
@@ -41,13 +41,13 @@ impl Vault {
     pub async fn get_token_or_login(&self) -> Result<String, VaultError> {
         let mut token = match self.get_token().await {
             Ok(token) => token,
-            Err(VaultError::ApiKeyNotFound) => self.handle_login().await?,
+            Err(VaultError::ApiTokenNotFound) => self.handle_login().await?,
             Err(err) => return Err(err),
         };
 
         match self.is_valid_token(&token).await {
             Ok(_) => Ok(token),
-            Err(VaultError::ApiKeyInvalid) => {
+            Err(VaultError::ApiTokenInvalid) => {
                 token = self.handle_login().await?;
                 Ok(token)
             }
@@ -166,7 +166,7 @@ impl Vault {
         let api_key = match &config_with_path.config.vault {
             Some(vault_config) => vault_config.api_key.clone(),
             None => {
-                return Err(VaultError::ApiKeyNotFound);
+                return Err(VaultError::ApiTokenNotFound);
             }
         };
 
@@ -197,7 +197,7 @@ impl Vault {
 
         match status {
             StatusCode::NOT_FOUND => Err(VaultError::SecretNotFound),
-            StatusCode::FORBIDDEN => Err(VaultError::ApiKeyInvalid),
+            StatusCode::FORBIDDEN => Err(VaultError::ApiTokenInvalid),
             StatusCode::BAD_REQUEST => {
                 if message.contains("Okta auth failed") {
                     Err(VaultError::AuthenticationFailed)

--- a/src/services/vault/mod.rs
+++ b/src/services/vault/mod.rs
@@ -146,7 +146,10 @@ impl Vault {
         let progress_bar = new_spinner_progress_bar();
         progress_bar.set_message("Updating secrets... ");
 
-        let response = self.vault_client.update_secret(api_token, path, data).await?;
+        let response = self
+            .vault_client
+            .update_secret(api_token, path, data)
+            .await?;
 
         progress_bar.finish_and_clear();
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Previously, when the module is initialised, module take care of whole login flow. However that might create side effects so we have detach the login flow with main functions and exposed the `get_token_or_login` to use before calling the api

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-466](https://mindvalley.atlassian.net/browse/PXP-466)

## What's Changed

<!-- Explain what is changed in this pull request -->

### Added

- [x]  Added `get_token_or_login` function

### Changed

- [x] Removed the login flow from `get_secret`, `update_secret` and `get_secrets`

<!-- ### Fixed -->

### Example
<img width="656" alt="Screenshot 2023-03-23 at 4 45 08 PM" src="https://user-images.githubusercontent.com/25294487/227151248-5492069b-17fd-4a55-9196-891f1519b77e.png">


[PXP-466]: https://mindvalley.atlassian.net/browse/PXP-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ