### PR TITLE
fix permission-secret mapping error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,8 +41,8 @@ pub enum VaultError {
     SecretNotFound,
     #[error("API token not found.")]
     ApiTokenNotFound,
-    #[error("Invalid API token.")]
-    ApiTokenInvalid,
+    #[error("Permission denied")]
+    ApiPermissionDenied,
 }
 
 #[derive(Debug, ThisError)]
@@ -139,6 +139,13 @@ If none of the above steps work for you, please contact the following people on 
                 ),
                 _ => None,
             },
+            CliError::VaultError(error) => match error {
+                VaultError::ApiPermissionDenied=> Some(
+                    String::from("Please check your secret path. It could be invalid or you don't have the permission to access it.")
+                ),
+                _ => None,
+            },
+
             _ => None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -141,7 +141,7 @@ If none of the above steps work for you, please contact the following people on 
             },
             CliError::VaultError(error) => match error {
                 VaultError::ApiPermissionDenied=> Some(
-                    String::from("Please check your secret path. It could be invalid or you don't have the permission to access it.")
+                    String::from("Please check your vault secret path. It could be invalid or you don't have the permission to access it.")
                 ),
                 _ => None,
             },

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,13 +139,9 @@ If none of the above steps work for you, please contact the following people on 
                 ),
                 _ => None,
             },
-            CliError::VaultError(error) => match error {
-                VaultError::ApiPermissionDenied=> Some(
-                    String::from("Please check your vault secret path. It could be invalid or you don't have the permission to access it.")
-                ),
-                _ => None,
+            CliError::VaultError(VaultError::ApiPermissionDenied) => {
+                Some(String::from("Please check your vault secret path. It could be invalid or you don't have the permission to access it."))
             },
-
             _ => None,
         }
     }

--- a/src/services/vault/mod.rs
+++ b/src/services/vault/mod.rs
@@ -47,7 +47,7 @@ impl Vault {
 
         match self.is_valid_token(&token).await {
             Ok(_) => Ok(token),
-            Err(VaultError::ApiTokenInvalid) => {
+            Err(VaultError::ApiPermissionDenied) => {
                 token = self.handle_login().await?;
                 Ok(token)
             }
@@ -200,7 +200,7 @@ impl Vault {
 
         match status {
             StatusCode::NOT_FOUND => Err(VaultError::SecretNotFound),
-            StatusCode::FORBIDDEN => Err(VaultError::ApiTokenInvalid),
+            StatusCode::FORBIDDEN => Err(VaultError::ApiPermissionDenied),
             StatusCode::BAD_REQUEST => {
                 if message.contains("Okta auth failed") {
                     Err(VaultError::AuthenticationFailed)


### PR DESCRIPTION
Previously, the code would throw a "secret not found on permission denied" error due to a mapping error between permissions and secrets. This commit fixes the issue by correcting the mapping and ensuring that the code handles permission-denied errors correctly.

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket:

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

<!-- ### Fixed -->
