### PR TITLE
PXP-530: [CLI] Support PATCH API for updating secrets in Bunker

### DIFF
--- a/src/services/vault/client.rs
+++ b/src/services/vault/client.rs
@@ -131,8 +131,9 @@ impl VaultClient {
 
         let response = self
             .client
-            .post(url)
+            .patch(url)
             .header("X-Vault-Token", api_token)
+            .header("Content-Type", "application/merge-patch+json")
             .json(&secret_data)
             .send()
             .await?;

--- a/src/services/vault/client.rs
+++ b/src/services/vault/client.rs
@@ -313,7 +313,7 @@ mod tests {
             }"#;
 
         let mock_server = server.mock(|when, then| {
-            when.method(POST)
+            when.method("PATCH")
                 .path_contains(VaultClient::UPDATE_SECRET)
                 .body(format!(r#"{{"data":{{"{}":"{}"}}}}"#, "test", "test4"))
                 .header("X-Vault-Token", api_token);


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

This merge request introduces the implementation of the PATCH API method for updating secrets in Bunker through the Wukong CLI. The motivation behind this enhancement is to leverage the latest version of Vault (>1.9.0) and its new endpoint, which allows updating secrets without sending the full payload.

Patch Endpoint Documentation: [Patch Secret Endpoint](https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#patch-secret)

Ticket: [PXP-530](https://mindvalley.atlassian.net/browse/PXP-530)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

- [x] Updated the Vault client to PATCH API method
- [x] Updated get_secrets functions to `get_secret` as we dont care about whole secret anymore 

<!-- ### Fixed -->


[PXP-530]: https://mindvalley.atlassian.net/browse/PXP-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ