### PR TITLE
PXP-538: Renew auth token

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,7 @@ pub struct CoreConfig {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct VaultConfig {
     pub api_token: String,
+    pub expiry_time: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,7 +68,7 @@ pub struct CoreConfig {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct VaultConfig {
     pub api_token: String,
-    pub expiry_time: Option<String>,
+    pub expiry_time: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -190,8 +190,7 @@ If none of the above steps work for you, please contact the following people on 
                 )),
                 _ => None,
             },
-            CliError::VaultError(error) => match error {
-                VaultError::ConfigError(error) => match error {
+            CliError::VaultError(VaultError::ConfigError(error)) => match error {
                     ConfigError::NotFound { .. } => Some(String::from(
                         "Run \"wukong init\" to initialise Wukong's configuration.",
                     )),
@@ -203,8 +202,6 @@ If none of the above steps work for you, please contact the following people on 
                     ),
                     _ => None,
                 },
-                _ => None,
-            },
             _ => None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -190,6 +190,21 @@ If none of the above steps work for you, please contact the following people on 
                 )),
                 _ => None,
             },
+            CliError::VaultError(error) => match error {
+                VaultError::ConfigError(error) => match error {
+                    ConfigError::NotFound { .. } => Some(String::from(
+                        "Run \"wukong init\" to initialise Wukong's configuration.",
+                    )),
+                    ConfigError::PermissionDenied { path, .. } => Some(format!(
+                        "Run \"chmod +rw {path}\" to provide read and write permissions."
+                    )),
+                    ConfigError::BadTomlData(_) => Some(
+                        "Check if your config.toml file is in valid TOML format.\nThis usually happen when the config file is accidentally modified or there is a breaking change to the cli config in the new version.\nYou may want to run \"wukong init\" to re-initialise configuration again.".to_string()
+                    ),
+                    _ => None,
+                },
+                _ => None,
+            },
             _ => None,
         }
     }

--- a/src/services/vault/client.rs
+++ b/src/services/vault/client.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Auth {
     pub client_token: String,
+    pub lease_duration: i64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/services/vault/client.rs
+++ b/src/services/vault/client.rs
@@ -46,6 +46,7 @@ pub struct VaultClient {
 
 impl VaultClient {
     pub const LOGIN: &str = "/v1/auth/okta/login";
+    pub const RENEW_TOKEN: &str = "/v1/auth/token/renew-self";
     pub const VERIFY_TOKEN: &str = "/v1/auth/token/lookup-self";
     pub const FETCH_SECRETS: &str = "/v1/secret/data";
     pub const UPDATE_SECRET: &str = "/v1/secret/data";
@@ -81,6 +82,24 @@ impl VaultClient {
             .client
             .post(url)
             .form(&[("password", password)])
+            .send()
+            .await?;
+
+        Ok(response)
+    }
+
+    pub async fn renew_token(
+        &self,
+        api_token: &str,
+        extend_duration: Option<&str>,
+    ) -> Result<reqwest::Response, reqwest::Error> {
+        let url = format!("{}{}", self.base_url, Self::RENEW_TOKEN);
+
+        let response = self
+            .client
+            .post(url)
+            .header("X-Vault-Token", api_token)
+            .form(&[("increment", extend_duration.unwrap_or("1h"))])
             .send()
             .await?;
 

--- a/src/services/vault/client.rs
+++ b/src/services/vault/client.rs
@@ -182,7 +182,8 @@ mod tests {
         let api_resp = r#"
             {
               "auth": {
-                "client_token": "test_token"
+                "client_token": "test_token",
+                "lease_duration": 0
                 }
             }"#;
 

--- a/src/services/vault/client.rs
+++ b/src/services/vault/client.rs
@@ -105,7 +105,7 @@ impl VaultClient {
             .client
             .post(url)
             .header("X-Vault-Token", api_token)
-            .form(&[("increment", extend_duration.unwrap_or("1h"))])
+            .form(&[("increment", extend_duration.unwrap_or("24h"))])
             .send()
             .await?;
 

--- a/src/services/vault/client.rs
+++ b/src/services/vault/client.rs
@@ -8,6 +8,11 @@ pub struct Auth {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct Renew {
+    pub auth: Auth,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Login {
     pub auth: Auth,
 }

--- a/src/services/vault/mod.rs
+++ b/src/services/vault/mod.rs
@@ -1,12 +1,12 @@
 pub mod client;
 
 use self::client::{FetchSecretsData, Login, VaultClient};
-use crate::config::VaultConfig;
 use crate::error::VaultError;
 use crate::loader::new_spinner_progress_bar;
 use crate::output::colored_println;
 use crate::services::vault::client::FetchSecrets;
 use crate::Config as CLIConfig;
+use crate::{config::VaultConfig, services::vault::client::Renew};
 use chrono::{DateTime, Duration, Local};
 use dialoguer::theme::ColorfulTheme;
 use log::debug;
@@ -37,30 +37,76 @@ impl Vault {
     }
 
     pub async fn get_token_or_login(&self) -> Result<String, VaultError> {
-        let mut token = match self.get_token().await {
-            Ok(token) => token,
+        let vault_config = match self.get_vault_config().await {
+            Ok(config) => config,
             Err(VaultError::ApiTokenNotFound) => self.handle_login().await?,
             Err(err) => return Err(err),
         };
 
-        match self.is_valid_token(&token).await {
+        match self.is_valid_token(&vault_config.api_token).await {
             Ok(_) => {
-                // Extend the token:
-                debug!("Extending the token expiration time");
-                let test = self.vault_client.renew_token(&token, None).await?;
-                debug!("renew token: {:?}", test);
-
-                Ok(token)
+                self.renew_token(vault_config.clone()).await?;
+                Ok(vault_config.api_token)
             }
             Err(VaultError::PermissionDenied) => {
-                token = self.handle_login().await?;
-                Ok(token)
+                let vault_config = self.handle_login().await?;
+                Ok(vault_config.api_token)
             }
             Err(err) => Err(err),
         }
     }
 
-    pub async fn handle_login(&self) -> Result<String, VaultError> {
+    async fn renew_token(&self, vault_config: VaultConfig) -> Result<(), VaultError> {
+        if let Some(expiry_time_str) = &vault_config.expiry_time {
+            let current_time: DateTime<Local> = Local::now();
+
+            if let Ok(expiry_time) = DateTime::parse_from_rfc3339(expiry_time_str) {
+                let remaining_duration = expiry_time.signed_duration_since(current_time);
+
+                if remaining_duration < Duration::hours(1) {
+                    let mut config_with_path = CLIConfig::get_config_with_path()?;
+
+                    debug!("Extending the token expiration time");
+                    let progress_bar = new_spinner_progress_bar();
+                    progress_bar.set_message(
+                        "Authenticating the user... You may need to check your device for an MFA notification.",
+                    );
+
+                    let response = self
+                        .vault_client
+                        .renew_token(&vault_config.api_token, None)
+                        .await?;
+
+                    if response.status().is_success() {
+                        let data = response.json::<Renew>().await?;
+
+                        let expiry_time = self.calculate_expiry_time(data.auth.lease_duration);
+
+                        config_with_path.config.vault = Some(VaultConfig {
+                            api_token: config_with_path
+                                .config
+                                .vault
+                                .api_token
+                                .clone()
+                                .expect("Vault api_token should be set"),
+                            expiry_time: Some(expiry_time),
+                        });
+
+                        config_with_path.config.save(&config_with_path.path)?;
+                    }
+
+                    progress_bar.finish_and_clear();
+                    debug!("renew token: {:?}", response);
+                }
+            } else {
+                debug!("Failed to parse expiry_time: {}", expiry_time_str);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn handle_login(&self) -> Result<VaultConfig, VaultError> {
         let mut config_with_path = CLIConfig::get_config_with_path()?;
 
         let email = match &config_with_path.config.auth {
@@ -101,7 +147,10 @@ impl Vault {
 
             colored_println!("You are now logged in as {}.\n", email);
 
-            Ok(data.auth.client_token)
+            Ok(config_with_path
+                .config
+                .vault
+                .expect("Vault config should be set"))
         } else {
             self.handle_error(response).await?;
             unreachable!()
@@ -173,18 +222,25 @@ impl Vault {
         Ok(true)
     }
 
-    async fn get_token(&self) -> Result<String, VaultError> {
-        debug!("Getting token ...");
+    async fn get_vault_config(&self) -> Result<VaultConfig, VaultError> {
+        debug!("Getting config...");
 
         let config_with_path = CLIConfig::get_config_with_path()?;
-        let api_token = match &config_with_path.config.vault {
-            Some(vault_config) => vault_config.api_token.clone(),
+
+        let vault_config = match &config_with_path.config.vault {
+            Some(vault_config) => {
+                if vault_config.api_token.is_empty() {
+                    return Err(VaultError::ApiTokenNotFound);
+                }
+
+                vault_config
+            }
             None => {
                 return Err(VaultError::ApiTokenNotFound);
             }
         };
 
-        Ok(api_token)
+        Ok(vault_config.clone())
     }
 
     async fn is_valid_token(&self, api_token: &str) -> Result<bool, VaultError> {

--- a/src/services/vault/mod.rs
+++ b/src/services/vault/mod.rs
@@ -77,18 +77,15 @@ impl Vault {
                         .renew_token(&vault_config.api_token, None)
                         .await?;
 
+                    debug!("renew token: {:?}", response);
+
                     if response.status().is_success() {
                         let data = response.json::<Renew>().await?;
 
                         let expiry_time = self.calculate_expiry_time(data.auth.lease_duration);
 
                         config_with_path.config.vault = Some(VaultConfig {
-                            api_token: config_with_path
-                                .config
-                                .vault
-                                .api_token
-                                .clone()
-                                .expect("Vault api_token should be set"),
+                            api_token: config_with_path.config.vault.unwrap().api_token,
                             expiry_time: Some(expiry_time),
                         });
 
@@ -96,7 +93,6 @@ impl Vault {
                     }
 
                     progress_bar.finish_and_clear();
-                    debug!("renew token: {:?}", response);
                 }
             } else {
                 debug!("Failed to parse expiry_time: {}", expiry_time_str);

--- a/src/services/vault/mod.rs
+++ b/src/services/vault/mod.rs
@@ -135,7 +135,7 @@ impl Vault {
             let expiry_time = self.calculate_expiry_time(data.auth.lease_duration);
 
             config_with_path.config.vault = Some(VaultConfig {
-                api_token: data.auth.client_token.clone(),
+                api_token: data.auth.client_token,
                 expiry_time: Some(expiry_time),
             });
 

--- a/src/services/vault/mod.rs
+++ b/src/services/vault/mod.rs
@@ -1,7 +1,7 @@
 pub mod client;
 
 use self::client::{FetchSecretsData, Login, VaultClient};
-use crate::error::{ConfigError, VaultError};
+use crate::error::VaultError;
 use crate::loader::new_spinner_progress_bar;
 use crate::output::colored_println;
 use crate::services::vault::client::FetchSecrets;
@@ -40,7 +40,7 @@ impl Vault {
         let vault_config = match self.get_vault_config().await {
             Ok(config) => config,
             Err(VaultError::ApiTokenNotFound) => self.handle_login().await?,
-            Err(err) => return Err(err.into()),
+            Err(err) => return Err(err),
         };
 
         match self.is_valid_token(&vault_config.api_token).await {

--- a/tests/dev_config.rs
+++ b/tests/dev_config.rs
@@ -91,6 +91,7 @@ fn mock_user_config(wk_temp: &assert_fs::TempDir, server_url: String) -> ChildPa
 
                     [vault]
                     api_token = "valid_vault_api_token"
+                    expiry_time = "2027-06-09T08:51:19.032792+00:00"
 
                     [auth]
                     account = "test@email.com"
@@ -447,6 +448,7 @@ okta_client_id = "valid-okta-client-id"
 
 [vault]
 api_token = "valid_vault_api_token"
+expiry_time = "2027-06-09T08:51:19.032792+00:00"
 
 [auth]
 account = "test@email.com"


### PR DESCRIPTION




<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

<!-- ### Fixed -->
## Summary
This pull request aims to enhance our Vault integration by implementing auth token renewal using the Vault API's auto-renew endpoint. Currently, wukong cli requires users to manually re-login to Vault after their tokens expire, which can be inconvenient for users making multiple Vault API calls.

Auto-Renew Endpoint Documentation: [Renew a Token (Self)](https://developer.hashicorp.com/vault/api-docs/auth/token#renew-a-token-self)

Ticket: [PXP-538](https://mindvalley.atlassian.net/browse/PXP-538)

## What's Changed
- [x] Add renewal endpoint to client vault
- [x] Utilized the auto-renew endpoint to extend the expiration time of tokens.
- [x] Renew the token if expiry is less then an hour




[PXP-538]: https://mindvalley.atlassian.net/browse/PXP-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ