### PR TITLE
Fix the reqwest error to stop the retrying during connection check

### DIFF
--- a/src/commands/application/instances/connect.rs
+++ b/src/commands/application/instances/connect.rs
@@ -118,7 +118,7 @@ pub async fn handle_connect(context: Context, name: &str, port: &u16) -> Result<
         let url = new_instance.url.unwrap_or_default();
 
         let mut connection_test_success = false;
-        for i in 0..3 {
+        for i in 0..20 {
             match reqwest::get(&url).await {
                 Ok(rs) => {
                     if rs.status().is_success() || rs.status().is_redirection() {
@@ -131,7 +131,7 @@ pub async fn handle_connect(context: Context, name: &str, port: &u16) -> Result<
                 }
             }
 
-            if i < 2 {
+            if i < 19 {
                 debug!("wait for 5 seconds and test again.");
                 sleep(std::time::Duration::from_secs(5)).await;
             }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

This PR addresses an issue encountered during the livebook instance connection test, where a Certificate error (from `reqwest`) may occur when the certificate is not yet ready. Currently, this error immediately halts the connection test retry process.

With this PR, we enables retries when encountering a `reqwest` error. In addition, detailed error information will be logged in the debug log.

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

### Fixed
- [x] retry the connection test when getting error from `reqwest` especially certificate error 
