### PR TITLE
PXP-547: [CLI] The cli is not working when the refresh token is expired.

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,6 +1,5 @@
-use crate::error::CliError;
+use crate::error::AuthError;
 use chrono::{Duration, Utc};
-use log::debug;
 use openidconnect::{
     core::{
         CoreClient, CoreIdTokenClaims, CoreIdTokenVerifier, CoreProviderMetadata, CoreResponseType,
@@ -49,7 +48,7 @@ impl Auth {
         }
     }
 
-    pub async fn login(&self) -> Result<AuthInfo, CliError> {
+    pub async fn login(&self) -> Result<AuthInfo, AuthError> {
         let okta_client_id = ClientId::new(self.api_key.clone());
 
         let issuer_url =
@@ -58,7 +57,7 @@ impl Auth {
         // Fetch Okta's OpenID Connect discovery document.
         let provider_metadata = CoreProviderMetadata::discover_async(issuer_url, async_http_client)
             .await
-            .map_err(|_err| CliError::OpenIDDiscoveryError)?;
+            .map_err(|_err| AuthError::OpenIDDiscoveryError)?;
 
         // Set up the config for the Okta OAuth2 process.
         let client = CoreClient::from_provider_metadata(provider_metadata, okta_client_id, None)
@@ -136,13 +135,39 @@ impl Auth {
         stream.write_all(response.as_bytes()).unwrap();
 
         // Exchange the code with a token.
+        // let token_response = client
+        //     .exchange_code(code)
+        //     .set_pkce_verifier(pkce_verifier)
+        //     .request_async(async_http_client)
+        //     .await
+        //     .map_err(|_err| CliError::AuthError {
+        //         message: "Failed to contact token endpoint",
+        //     })?;
+
         let token_response = client
             .exchange_code(code)
             .set_pkce_verifier(pkce_verifier)
             .request_async(async_http_client)
             .await
-            .map_err(|_err| CliError::AuthError {
-                message: "Failed to contact token endpoint",
+            .map_err(|err| match err {
+                openidconnect::RequestTokenError::ServerResponse(error) => {
+                    let error_description = error.to_string();
+                    if error.error().to_string() == "invalid_grant"
+                        && error_description.contains("refresh token")
+                        && error_description.contains("expired")
+                    {
+                        AuthError::RefreshTokenExpired {
+                            message: error_description,
+                        }
+                    } else {
+                        AuthError::OpenIDConnectError {
+                            message: "Failed to contact token endpoint".to_string(),
+                        }
+                    }
+                }
+                _ => AuthError::OpenIDConnectError {
+                    message: "Failed to contact token endpoint".to_string(),
+                },
             })?;
 
         let id_token_verifier: CoreIdTokenVerifier = client.id_token_verifier();
@@ -164,8 +189,8 @@ impl Auth {
 
         let id_token_claims: &CoreIdTokenClaims = id_token
             .claims(&id_token_verifier, &nonce)
-            .map_err(|_err| CliError::AuthError {
-                message: "Failed to verify ID token",
+            .map_err(|_err| AuthError::OpenIDConnectError {
+                message: "Failed to verify ID token".to_string(),
             })?;
 
         // Verify the access token hash to ensure that the access token hasn't been substituted for
@@ -205,7 +230,7 @@ impl Auth {
     pub async fn refresh_tokens(
         &self,
         refresh_token: &RefreshToken,
-    ) -> Result<TokenInfo, CliError> {
+    ) -> Result<TokenInfo, AuthError> {
         let okta_client_id = ClientId::new(self.api_key.clone());
 
         let issuer_url =
@@ -214,7 +239,7 @@ impl Auth {
         // Fetch Okta's OpenID Connect discovery document.
         let provider_metadata = CoreProviderMetadata::discover_async(issuer_url, async_http_client)
             .await
-            .map_err(|_err| CliError::OpenIDDiscoveryError)?;
+            .map_err(|_err| AuthError::OpenIDDiscoveryError)?;
 
         // Set up the config for the Okta OAuth2 process.
         let client = CoreClient::from_provider_metadata(provider_metadata, okta_client_id, None)
@@ -227,11 +252,25 @@ impl Auth {
             .exchange_refresh_token(refresh_token)
             .request_async(async_http_client)
             .await
-            .map_err(|err| {
-                debug!("Error when refreshing token: {:?}", err);
-                CliError::AuthError {
-                    message: "Failed to contact token endpoint",
+            .map_err(|err| match err {
+                openidconnect::RequestTokenError::ServerResponse(error) => {
+                    let error_description = error.to_string();
+                    if error.error().to_string() == "invalid_grant"
+                        && error_description.contains("refresh token")
+                        && error_description.contains("expired")
+                    {
+                        AuthError::RefreshTokenExpired {
+                            message: error_description,
+                        }
+                    } else {
+                        AuthError::OpenIDConnectError {
+                            message: "Failed to contact token endpoint".to_string(),
+                        }
+                    }
                 }
+                _ => AuthError::OpenIDConnectError {
+                    message: "Failed to contact token endpoint".to_string(),
+                },
             })?;
 
         let id_token = token_response

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -135,15 +135,6 @@ impl Auth {
         stream.write_all(response.as_bytes()).unwrap();
 
         // Exchange the code with a token.
-        // let token_response = client
-        //     .exchange_code(code)
-        //     .set_pkce_verifier(pkce_verifier)
-        //     .request_async(async_http_client)
-        //     .await
-        //     .map_err(|_err| CliError::AuthError {
-        //         message: "Failed to contact token endpoint",
-        //     })?;
-
         let token_response = client
             .exchange_code(code)
             .set_pkce_verifier(pkce_verifier)

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,18 +1,23 @@
 use crate::{
     auth::Auth,
     config::{AuthConfig, CONFIG_FILE},
-    error::CliError,
+    error::{AuthError, CliError},
+    loader::new_spinner_progress_bar,
     output::colored_println,
     Config as CLIConfig,
 };
+use aion::*;
+use chrono::{DateTime, Local};
 use dialoguer::{theme::ColorfulTheme, Select};
+use log::debug;
+use openidconnect::RefreshToken;
 
 pub async fn handle_login() -> Result<bool, CliError> {
     let config_file = CONFIG_FILE
         .as_ref()
         .expect("Unable to identify user's home directory");
 
-    let config = CLIConfig::load(config_file)?;
+    let mut config = CLIConfig::load(config_file)?;
 
     if let Some(auth_config) = &config.auth {
         let selections = vec![
@@ -31,6 +36,50 @@ pub async fn handle_login() -> Result<bool, CliError> {
         // selecting "Log in with a new account"
         if selection == 1 {
             login_and_update_config(config).await?;
+        } else {
+            // checking the refresh token
+            let auth_config = config.auth.as_ref().unwrap();
+
+            let current_time: DateTime<Local> = Local::now();
+            let expiry = DateTime::parse_from_rfc3339(&auth_config.expiry_time)
+                .unwrap()
+                .with_timezone(&Local);
+            let remaining_duration = expiry.signed_duration_since(current_time);
+
+            if remaining_duration < 5.minutes() {
+                debug!("Access token expired. Refreshing tokens...");
+
+                let refresh_token_loader = new_spinner_progress_bar();
+                refresh_token_loader.set_message("Refreshing tokens...");
+
+                match Auth::new(&config.core.okta_client_id)
+                    .refresh_tokens(&RefreshToken::new(auth_config.refresh_token.clone()))
+                    .await
+                {
+                    Ok(new_tokens) => {
+                        config.auth = Some(AuthConfig {
+                            account: auth_config.account.clone(),
+                            subject: auth_config.subject.clone(),
+                            id_token: new_tokens.id_token.clone(),
+                            access_token: new_tokens.access_token.clone(),
+                            expiry_time: new_tokens.expiry_time,
+                            refresh_token: new_tokens.refresh_token,
+                        });
+
+                        refresh_token_loader.finish_and_clear();
+                    }
+                    Err(err) => {
+                        refresh_token_loader.finish_and_clear();
+                        match err {
+                            AuthError::RefreshTokenExpired { .. } => {
+                                eprintln!("The refresh token is expired. You have to login again.");
+                                login_and_update_config(config).await?;
+                            }
+                            err => return Err(err.into()),
+                        }
+                    }
+                }
+            }
         }
     } else {
         login_and_update_config(config).await?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -211,8 +211,7 @@ If none of the above steps work for you, please contact the following people on 
                 )),
                 _ => None,
             },
-            CliError::AuthError(AuthError::RefreshTokenExpired { .. }) => 
-                Some("Your refresh token is expired. Run \"wukong login\" to authenticate again.".to_string()),
+            CliError::AuthError(AuthError::RefreshTokenExpired { .. }) => Some("Your refresh token is expired. Run \"wukong login\" to authenticate again.".to_string()),
             _ => None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,8 +27,8 @@ pub enum CliError {
     UnAuthenticated,
     #[error("You are un-initialised.")]
     UnInitialised,
-    #[error("{message}")]
-    AuthError { message: &'static str },
+    #[error(transparent)]
+    AuthError(#[from] AuthError),
     #[error(transparent)]
     DeploymentError(#[from] DeploymentError),
     #[error(transparent)]
@@ -37,6 +37,16 @@ pub enum CliError {
     DevConfigError(#[from] DevConfigError),
     #[error(transparent)]
     GCloudError(#[from] GCloudError),
+}
+
+#[derive(Debug, ThisError)]
+pub enum AuthError {
+    #[error("Refresh token expired: {message}")]
+    RefreshTokenExpired { message: String },
+    #[error("OpenID Connect Error: {message}")]
+    OpenIDConnectError { message: String },
+    #[error("Failed to discover OpenID Provider")]
+    OpenIDDiscoveryError,
 }
 
 #[derive(Debug, ThisError)]
@@ -201,6 +211,8 @@ If none of the above steps work for you, please contact the following people on 
                 )),
                 _ => None,
             },
+            CliError::AuthError(AuthError::RefreshTokenExpired { .. }) => 
+                Some("Your refresh token is expired. Run \"wukong login\" to authenticate again.".to_string()),
             _ => None,
         }
     }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->
<img width="1688" alt="Screenshot 2023-06-09 at 2 36 37 PM" src="https://github.com/mindvalley/wukong-cli/assets/7545747/c08eac22-5f59-4936-829e-50bcc8791378">


Ticket: [PXP-547](https://mindvalley.atlassian.net/browse/PXP-547)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

### Fixed
- [x] The cli now will suggest user to run `wukong login` when the refresh token is expired
- [x] The `wukong init` and `wukong login` is able to handle refresh token expired error by asking user to login again


[PXP-547]: https://mindvalley.atlassian.net/browse/PXP-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ