### PR TITLE
PXP-549: [API] Google Cloud Oauth2 does not have the resfresh token

### DIFF
--- a/src/services/gcloud/mod.rs
+++ b/src/services/gcloud/mod.rs
@@ -30,12 +30,13 @@ use yup_oauth2::{
 /// we use the existing `DefaultInstalledFlowDelegate::present_user_url` method as a fallback for
 /// when the browser did not open for example, the user still see's the URL.
 async fn browser_user_url(url: &str, need_code: bool) -> Result<String, String> {
-    if webbrowser::open(url).is_ok() {
+    let url = format!("{}&prompt=consent", url);
+    if webbrowser::open(&url).is_ok() {
         println!("Your browser has been opened to visit:\n\n\t{url}\n");
         Ok(String::new())
     } else {
         let def_delegate = DefaultInstalledFlowDelegate;
-        def_delegate.present_user_url(url, need_code).await
+        def_delegate.present_user_url(&url, need_code).await
     }
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-549](https://mindvalley.atlassian.net/browse/PXP-549)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

### Fixed
- [x] Add `prompt=consent` to the redirect url to obtain refresh token https://stackoverflow.com/a/65702100


[PXP-549]: https://mindvalley.atlassian.net/browse/PXP-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ