### PR TITLE
PXP-548: [CLI] Program does not exit on Ctrl-C key press

### DIFF
--- a/src/commands/application/instances/connect.rs
+++ b/src/commands/application/instances/connect.rs
@@ -167,14 +167,8 @@ pub async fn handle_connect(context: Context, name: &str, port: &u16) -> Result<
     running_progress_bar
         .set_message("Your livebook instance is running. Press Ctrl-C to terminate...");
 
-    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::signal::ctrl_c().await.unwrap();
 
-    tokio::spawn(async move {
-        tokio::signal::ctrl_c().await.unwrap();
-        tx.send(()).expect("Could not send signal on channel.")
-    });
-
-    rx.await.expect("Could not receive from channel.");
     running_progress_bar.finish_and_clear();
     let exiting_progress_bar = new_spinner_progress_bar();
     exiting_progress_bar.set_message("You're exiting from your remote session. Cleaning up...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,12 @@ async fn main() {
     setup_panic!();
 
     // make sure that the cursor re-appears when interrupting
-    tokio::spawn(async move {
-        tokio::signal::ctrl_c().await.unwrap();
-        let term = dialoguer::console::Term::stdout();
-        let _ = term.show_cursor();
-    });
+    // tokio::spawn(async move {
+    //     tokio::signal::ctrl_c().await.unwrap();
+    //     let term = dialoguer::console::Term::stdout();
+    //     let _ = term.show_cursor();
+    //     process::exit(1);
+    // });
 
     match run().await {
         Err(error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use wukong::{output::error::ErrorOutput, run};
 async fn main() {
     setup_panic!();
 
-    // make sure that the cursor re-appears when interrupting
+    // TODO: make sure that the cursor re-appears when interrupting
     // tokio::spawn(async move {
     //     tokio::signal::ctrl_c().await.unwrap();
     //     let term = dialoguer::console::Term::stdout();


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The root cause of this is because we have 2 `ctrl-c` handlers, and they are conflicted with each other. I do a quick fix by removing the first `ctrl-c` handler (the one to show the cursor after `ctrl-c`) because I believe that unable to exit the cli with `ctrl-c` is much more annoying. 

Another solution I can think of is to use other key to close the instance connection, so we won't have the conflict at the first place. 

There are few ways to handle the signal too (https://tokio.rs/tokio/topics/shutdown), but this requires some refactoring. I think we can do this in the v2 implementation.

<!-- Link any relevant issues or Jira ticket if necessary -->


Ticket: [PXP-548](https://mindvalley.atlassian.net/browse/PXP-548)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

### Fixed
- [x] fix the `ctrl-c` signal don't exit the cli issue


[PXP-548]: https://mindvalley.atlassian.net/browse/PXP-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ