### PR TITLE
PXP-571: [CLI] Send telemetry data for new command groups

### DIFF
--- a/crates/wukong_telemetry_macro/src/lib.rs
+++ b/crates/wukong_telemetry_macro/src/lib.rs
@@ -24,6 +24,7 @@ pub fn wukong_telemetry(args: TokenStream, item: TokenStream) -> TokenStream {
 
     if let Some(command_event) = command_event_value {
         generated_func = quote! {
+            #[allow(clippy::too_many_arguments)]
             #visibility #asyncness fn #fn_ident(#fn_inputs) #fn_output {
                 // SAFETY: the application can't be None since it is checked in the caller
                 let current_application = context.state.application.as_ref().expect("Current application must not be None for command event telemetry.").clone();

--- a/src/commands/application/logs.rs
+++ b/src/commands/application/logs.rs
@@ -5,6 +5,7 @@ use crate::{
     graphql::QueryClient,
     loader::new_spinner_progress_bar,
     services::gcloud::{google::logging::v2::LogEntry, GCloudClient, LogEntriesOptions},
+    telemetry::{self, TelemetryData, TelemetryEvent},
 };
 use aion::*;
 use chrono::{DateTime, Local};
@@ -13,6 +14,7 @@ use once_cell::sync::Lazy;
 use owo_colors::OwoColorize;
 use regex::Regex;
 use std::fmt::Display;
+use wukong_telemetry_macro::wukong_telemetry;
 
 impl Display for LogEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -110,7 +112,7 @@ fn display_prost_type_value_kind(kind: Option<prost_types::value::Kind>) -> Stri
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[wukong_telemetry(command_event = "application_logs")]
 pub async fn handle_logs(
     context: Context,
     namespace: &ApplicationNamespace,

--- a/src/commands/dev/config/diff.rs
+++ b/src/commands/dev/config/diff.rs
@@ -1,17 +1,21 @@
+use crate::commands::Context;
 use crate::error::{CliError, DevConfigError};
 use crate::loader::new_spinner_progress_bar;
 use crate::services::vault::Vault;
+use crate::telemetry::{self, TelemetryData, TelemetryEvent};
 use crate::utils::line::Line;
 use dialoguer::console::{style, Style};
 use owo_colors::OwoColorize;
 use similar::{ChangeTag, TextDiff};
+use wukong_telemetry_macro::wukong_telemetry;
 
 use super::utils::{
     extract_secret_infos, get_local_config_path, get_secret_config_files, get_updated_configs,
     make_path_relative,
 };
 
-pub async fn handle_config_diff() -> Result<bool, CliError> {
+#[wukong_telemetry(command_event = "dev_config_diff")]
+pub async fn handle_config_diff(context: Context) -> Result<bool, CliError> {
     let progress_bar = new_spinner_progress_bar();
     progress_bar.set_message("🔍 Finding config with annotation");
 

--- a/src/commands/dev/config/mod.rs
+++ b/src/commands/dev/config/mod.rs
@@ -4,7 +4,10 @@ mod pull;
 mod push;
 mod utils;
 
-use crate::{commands::Context, error::CliError};
+use crate::{
+    commands::{Context, State},
+    error::CliError,
+};
 use clap::{Args, Subcommand};
 use diff::handle_config_diff;
 use lint::handle_config_lint;
@@ -39,11 +42,20 @@ pub enum ConfigSubcommand {
 }
 
 impl Config {
-    pub async fn handle_command(&self, context: Context) -> Result<bool, CliError> {
+    pub async fn handle_command(&self, state: State) -> Result<bool, CliError> {
         match &self.subcommand {
-            ConfigSubcommand::Push => handle_config_push(context).await,
-            ConfigSubcommand::Diff => handle_config_diff(context).await,
-            ConfigSubcommand::Pull { path } => handle_config_pull(context, path).await,
+            ConfigSubcommand::Push => {
+                let context = Context::from_state(state).await?;
+                handle_config_push(context).await
+            }
+            ConfigSubcommand::Diff => {
+                let context = Context::from_state(state).await?;
+                handle_config_diff(context).await
+            }
+            ConfigSubcommand::Pull { path } => {
+                let context = Context::from_state(state).await?;
+                handle_config_pull(context, path).await
+            }
             ConfigSubcommand::Lint { path } => handle_config_lint(path),
         }
     }

--- a/src/commands/dev/config/mod.rs
+++ b/src/commands/dev/config/mod.rs
@@ -4,7 +4,7 @@ mod pull;
 mod push;
 mod utils;
 
-use crate::error::CliError;
+use crate::{commands::Context, error::CliError};
 use clap::{Args, Subcommand};
 use diff::handle_config_diff;
 use lint::handle_config_lint;
@@ -39,11 +39,11 @@ pub enum ConfigSubcommand {
 }
 
 impl Config {
-    pub async fn handle_command(&self) -> Result<bool, CliError> {
+    pub async fn handle_command(&self, context: Context) -> Result<bool, CliError> {
         match &self.subcommand {
-            ConfigSubcommand::Push => handle_config_push().await,
-            ConfigSubcommand::Diff => handle_config_diff().await,
-            ConfigSubcommand::Pull { path } => handle_config_pull(path).await,
+            ConfigSubcommand::Push => handle_config_push(context).await,
+            ConfigSubcommand::Diff => handle_config_diff(context).await,
+            ConfigSubcommand::Pull { path } => handle_config_pull(context, path).await,
             ConfigSubcommand::Lint { path } => handle_config_lint(path),
         }
     }

--- a/src/commands/dev/config/pull.rs
+++ b/src/commands/dev/config/pull.rs
@@ -1,15 +1,19 @@
 use crate::commands::dev::config::utils::get_local_config_path;
+use crate::commands::Context;
 use crate::services::vault::client::FetchSecretsData;
+use crate::telemetry::{self, TelemetryData, TelemetryEvent};
 use crate::{error::CliError, services::vault::Vault};
 use log::debug;
 use owo_colors::OwoColorize;
 use std::collections::HashMap;
 use std::io::{prelude::*, ErrorKind};
 use std::{env::current_dir, fs::File, path::Path};
+use wukong_telemetry_macro::wukong_telemetry;
 
 use super::utils::{extract_secret_infos, get_secret_config_files};
 
-pub async fn handle_config_pull(path: &Path) -> Result<bool, CliError> {
+#[wukong_telemetry(command_event = "dev_config_pull")]
+pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, CliError> {
     let path = path.try_exists().map(|value| match value {
         true => {
             if path.to_string_lossy() == "." {

--- a/src/commands/dev/config/push.rs
+++ b/src/commands/dev/config/push.rs
@@ -1,11 +1,14 @@
+use crate::commands::Context;
 use crate::error::DevConfigError;
 use crate::loader::new_spinner_progress_bar;
+use crate::telemetry::{self, TelemetryData, TelemetryEvent};
 use crate::utils::secret_extractors::SecretInfo;
 use crate::{error::CliError, services::vault::Vault};
 use dialoguer::Confirm;
 use dialoguer::{theme::ColorfulTheme, Select};
 use owo_colors::OwoColorize;
 use std::collections::HashMap;
+use wukong_telemetry_macro::wukong_telemetry;
 
 use super::diff::print_diff;
 use super::utils::{
@@ -13,7 +16,8 @@ use super::utils::{
     get_secret_config_files, get_updated_configs, make_path_relative,
 };
 
-pub async fn handle_config_push() -> Result<bool, CliError> {
+#[wukong_telemetry(command_event = "dev_config_push")]
+pub async fn handle_config_push(context: Context) -> Result<bool, CliError> {
     let progress_bar = new_spinner_progress_bar();
     progress_bar.set_message("🔍 Finding config with annotation");
 

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -3,6 +3,8 @@ mod config;
 use crate::error::CliError;
 use clap::{Args, Subcommand};
 
+use super::{Context, State};
+
 #[derive(Debug, Args)]
 pub struct Dev {
     #[command(subcommand)]
@@ -16,9 +18,11 @@ pub enum DevSubcommand {
 }
 
 impl Dev {
-    pub async fn handle_command(&self) -> Result<bool, CliError> {
+    pub async fn handle_command(&self, state: State) -> Result<bool, CliError> {
+        let context = Context::from_state(state).await?;
+
         match &self.subcommand {
-            DevSubcommand::Config(config) => config.handle_command().await,
+            DevSubcommand::Config(config) => config.handle_command(context).await,
         }
     }
 }

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -3,7 +3,7 @@ mod config;
 use crate::error::CliError;
 use clap::{Args, Subcommand};
 
-use super::{Context, State};
+use super::State;
 
 #[derive(Debug, Args)]
 pub struct Dev {
@@ -19,10 +19,8 @@ pub enum DevSubcommand {
 
 impl Dev {
     pub async fn handle_command(&self, state: State) -> Result<bool, CliError> {
-        let context = Context::from_state(state).await?;
-
         match &self.subcommand {
-            DevSubcommand::Config(config) => config.handle_command(context).await,
+            DevSubcommand::Config(config) => config.handle_command(state).await,
         }
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -175,7 +175,7 @@ impl ClapApp {
             CommandGroup::Pipeline(pipeline) => pipeline.handle_command(state).await,
             CommandGroup::Deployment(deployment) => deployment.handle_command(state).await,
             CommandGroup::Config(config) => config.handle_command(),
-            CommandGroup::Dev(dev) => dev.handle_command().await,
+            CommandGroup::Dev(dev) => dev.handle_command(state).await,
         }
     }
 }

--- a/tests/dev_config.rs
+++ b/tests/dev_config.rs
@@ -454,12 +454,15 @@ config :application, Application.Repo"#,
 #[test]
 #[serial]
 fn test_wukong_dev_config_diff_when_config_not_found() {
+    let server = MockServer::start();
     let (wk_temp, elixir_temp) = setup();
+    let wk_config_file = mock_user_config(&wk_temp, server.base_url());
 
     let cmd = common::wukong_raw_command()
         .arg("dev")
         .arg("config")
         .arg("diff")
+        .env("WUKONG_DEV_CONFIG_FILE", wk_config_file.path())
         .assert()
         .failure();
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-571](https://mindvalley.atlassian.net/browse/PXP-571)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->
- [x] Add telemetry to `wukong application instances connect`
- [x] Add telemetry to `wukong application logs`
- [x] Add telemetry to `wukong dev config diff`
- [x] Add telemetry to `wukong dev config pull`
- [x] Add telemetry to `wukong dev config push`

<!-- ### Changed -->

### Fixed
- [x] fix cli panic when the user don't have enough permission during `wukong application instances connect`


[PXP-571]: https://mindvalley.atlassian.net/browse/PXP-571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ