### PR TITLE
PXP-572: Handle blue/green deployment failure on deployment

### DIFF
--- a/src/commands/application/instances/connect.rs
+++ b/src/commands/application/instances/connect.rs
@@ -10,7 +10,7 @@ use crate::{
     output::colored_println,
     telemetry::{self, TelemetryData, TelemetryEvent},
 };
-use dialoguer::{theme::ColorfulTheme, Select};
+use dialoguer::{theme::ColorfulTheme, Confirm, Select};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use log::debug;
 use owo_colors::OwoColorize;
@@ -32,6 +32,10 @@ struct KubernetesPod {
     name: String,
     ready: bool,
     is_livebook: Option<bool>,
+}
+
+fn capitalize_first_letter(o: &str) -> String {
+    o[0..1].to_uppercase() + &o[1..]
 }
 
 #[wukong_telemetry(command_event = "application_instances_connect")]
@@ -66,7 +70,7 @@ pub async fn handle_connect(
             "{} {} `{}` {}\n",
             "✔".green(),
             "Step 1: You've selected".bold(),
-            namespace.green(),
+            capitalize_first_letter(&namespace).green(),
             "namespace.".bold()
         );
     }
@@ -81,9 +85,40 @@ pub async fn handle_connect(
             "{} {} `{}` {}\n",
             "✔".green(),
             "Step 2: You've selected".bold(),
-            version.green(),
+            capitalize_first_letter(&version).green(),
             "version.".bold()
         );
+    }
+
+    let mut client = QueryClient::from_default_config()?;
+
+    println!(
+        "{} {} {} {}",
+        "✔".green(),
+        "Step 3: Checking the status of the latest".bold(),
+        capitalize_first_letter(&version).green(),
+        "deployment...".bold()
+    );
+
+    let deployment_status =
+        get_deployment_status(&mut client, &application, &namespace, &version).await?;
+
+    println!("Deployment status: {}\n", deployment_status);
+
+    if deployment_status != "SUCCEEDED" {
+        let agree_to_continue = Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt(
+                    format!(
+                    "It seems the {0} deployment is not in a stable state, are you still want to proceed with the {0} deployment ?",
+                        capitalize_first_letter(&version).green(),
+                    )
+                )
+                .default(false)
+                .interact()?;
+
+        if !agree_to_continue {
+            return Ok(false);
+        }
     }
 
     let check_permission_progress_bar = new_spinner_progress_bar();
@@ -91,8 +126,6 @@ pub async fn handle_connect(
     check_permission_progress_bar.set_prefix("[1/2]");
     check_permission_progress_bar
         .set_message("Checking your permission to connect to the remote instance...");
-
-    let mut client = QueryClient::from_default_config()?;
 
     if !has_permission(&mut client, &application, &namespace, &version).await? {
         check_permission_progress_bar.finish_and_clear();
@@ -296,6 +329,36 @@ pub async fn handle_connect(
     }
 
     Ok(true)
+}
+
+async fn get_deployment_status(
+    client: &mut QueryClient,
+    application: &str,
+    namespace: &str,
+    version: &str,
+) -> Result<String, CliError> {
+    let deployments = client
+        .fetch_cd_pipeline(application, namespace, version)
+        .await?
+        .data
+        .unwrap()
+        .cd_pipeline;
+
+    let latest_deployment = deployments
+        .iter()
+        .find(|deployment| deployment.last_successfully_deployed_artifact.is_some());
+
+    if latest_deployment.is_none() {
+        Ok(String::from("TERMINAL"))
+    } else {
+        let deployment_status = latest_deployment.unwrap().status.clone();
+
+        if deployment_status.is_none() {
+            Ok(String::from("TERMINAL"))
+        } else {
+            Ok(deployment_status.unwrap())
+        }
+    }
 }
 
 async fn cleanup_previous_livebook_instance(

--- a/src/commands/deployment/execute.rs
+++ b/src/commands/deployment/execute.rs
@@ -359,7 +359,7 @@ pub async fn handle_execute(
         println!(
             "{} {} `{}`.\n",
             "✔".green(),
-            "Step 3: You've selected build artifact".bold(),
+            "Step 4: You've selected build artifact".bold(),
             selected_build.green()
         );
     } else {
@@ -482,7 +482,7 @@ pub async fn handle_execute(
                     BuildSelectionLayout::TwoColumns { data } => {
                         Select::with_theme(&ColorfulTheme::default())
                             .with_prompt(
-                                "Step 3: Please choose the build artifact you want to deploy",
+                                "Step 4: Please choose the build artifact you want to deploy",
                             )
                             .default(0)
                             .items(&data[..])
@@ -491,7 +491,7 @@ pub async fn handle_execute(
                     BuildSelectionLayout::ThreeColumns { data } => {
                         Select::with_theme(&ColorfulTheme::default())
                             .with_prompt(
-                                "Step 3: Please choose the build artifact you want to deploy (* is the current deployed build)",
+                                "Step 4: Please choose the build artifact you want to deploy (* is the current deployed build)",
                             )
                             .default(0)
                             .items(&data[..])
@@ -593,7 +593,7 @@ pub async fn handle_execute(
             .collect::<Vec<&str>>()
             .join("\n");
 
-        println!("{}", "Step 4: Review your deployment".bold());
+        println!("{}", "Step 5: Review your deployment".bold());
         println!("Please review your deployment CHANGELOG before execute it.\n");
         println!("{cleaned_changelog}");
 

--- a/src/commands/deployment/execute.rs
+++ b/src/commands/deployment/execute.rs
@@ -319,26 +319,29 @@ pub async fn handle_execute(
         "green".to_string()
     };
 
-    println!(
-        "{} {} {} {}",
-        "✔".green(),
-        "Step 3: Checking the status of the latest".bold(),
-        capitalize_first_letter(&inverse_version).green(),
-        "deployment...".bold()
-    );
+    if inverse_version == "green" && has_green_version
+        || inverse_version == "blue" && has_blue_version
+    {
+        println!(
+            "{} {} {} {}",
+            "✔".green(),
+            "Step 3: Checking the status of the latest".bold(),
+            capitalize_first_letter(&inverse_version).green(),
+            "deployment...".bold()
+        );
 
-    let deployment_status = get_deployment_status(
-        &mut client,
-        &current_application,
-        &selected_namespace.to_lowercase(),
-        &inverse_version,
-    )
-    .await?;
+        let deployment_status = get_deployment_status(
+            &mut client,
+            &current_application,
+            &selected_namespace.to_lowercase(),
+            &inverse_version,
+        )
+        .await?;
 
-    println!("Deployment status: {}\n", deployment_status.bold());
+        println!("Deployment status: {}\n", deployment_status.bold());
 
-    if deployment_status != "SUCCEEDED" {
-        let agree_to_continue = Confirm::with_theme(&ColorfulTheme::default())
+        if deployment_status != "SUCCEEDED" {
+            let agree_to_continue = Confirm::with_theme(&ColorfulTheme::default())
                 .with_prompt(
                     format!(
                     "It seems the {} deployment is not in a stable state, are you still want to proceed with the {} deployment ?",
@@ -349,8 +352,9 @@ pub async fn handle_execute(
                 .default(false)
                 .interact()?;
 
-        if !agree_to_continue {
-            return Ok(false);
+            if !agree_to_continue {
+                return Ok(false);
+            }
         }
     }
 

--- a/src/commands/deployment/execute.rs
+++ b/src/commands/deployment/execute.rs
@@ -313,21 +313,36 @@ pub async fn handle_execute(
         println!("You've selected `{selected_version}` as the deployment version.\n");
     }
 
+    let inverse_version = if selected_version.to_lowercase() == "green" {
+        "blue".to_string()
+    } else {
+        "green".to_string()
+    };
+
+    println!(
+        "{} {} {} {}",
+        "✔".green(),
+        "Step 3: Checking the status of the latest".bold(),
+        capitalize_first_letter(&inverse_version).green(),
+        "deployment...".bold()
+    );
+
     let deployment_status = get_deployment_status(
         &mut client,
         &current_application,
-        &selected_namespace,
-        &selected_version,
+        &selected_namespace.to_lowercase(),
+        &inverse_version,
     )
     .await?;
 
-    println!("Deployment status: {}\n", deployment_status);
+    println!("Deployment status: {}\n", deployment_status.bold());
 
     if deployment_status != "SUCCEEDED" {
         let agree_to_continue = Confirm::with_theme(&ColorfulTheme::default())
                 .with_prompt(
                     format!(
-                    "It seems the {0} deployment is not in a stable state, are you still want to proceed with the {0} deployment ?",
+                    "It seems the {} deployment is not in a stable state, are you still want to proceed with the {} deployment ?",
+                        capitalize_first_letter(&inverse_version).green(),
                         capitalize_first_letter(&selected_version).green(),
                     )
                 )

--- a/src/commands/deployment/execute.rs
+++ b/src/commands/deployment/execute.rs
@@ -356,6 +356,15 @@ pub async fn handle_execute(
                 return Ok(false);
             }
         }
+    } else {
+        println!(
+            "{} {} {} {}",
+            "✔".green(),
+            "Step 3: Skipping checking the status of the latest deployment because there is no"
+                .bold(),
+            capitalize_first_letter(&inverse_version).green(),
+            "deployment...".bold()
+        );
     }
 
     if let Some(artifact) = artifact {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

Currently with an application that is having Blue-Green deployment topology, we don’t have an effective method to guarantee that the Blue deployment is running BEFORE sending the Green deployment however Mindvalley does not follow this practice yet so need additional handling to check for the deployment status, and ask for confirmation if there is any failure.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [https://mindvalley.atlassian.net/browse/PXP-572](https://mindvalley.atlassian.net/browse/PXP-572)

## What's Changed

- [x]  Added additional confirmation if there is failure on last deployment

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

<!-- ### Fixed -->

#### CASE 1: BLUE deployment is succeeded
![Screenshot 2023-08-01 at 4 03 03 PM](https://github.com/mindvalley/wukong-cli/assets/25294487/1e5970f9-94bd-4124-aa04-5d6f1bd18284)


#### CASE 2: BLUE deployment is not  succeeded
![Screenshot 2023-08-01 at 4 01 43 PM](https://github.com/mindvalley/wukong-cli/assets/25294487/887ef09c-8fa0-448e-9132-892667d4262b)
