### PR TITLE
PXP-604: handle permission error for the TUI

### DIFF
--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -35,6 +35,7 @@ pub struct State {
     pub builds: Vec<Build>,
     pub deployments: Vec<Deployment>,
     pub log_entries_hash_map: HashMap<String, LogEntry>,
+    pub has_log_errors: bool,
     pub log_entries_ids: Vec<String>,
     // pub log_entries_next_page_token: Option<String>,
     pub last_log_entry_timestamp: Option<String>,
@@ -105,6 +106,7 @@ impl App {
                 last_log_entry_timestamp: None,
                 log_entries_hash_map: HashMap::new(),
                 log_entries_ids: vec![],
+                has_log_errors: false,
 
                 logs_vertical_scroll_state: ScrollbarState::default(),
                 logs_horizontal_scroll_state: ScrollbarState::default(),

--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -42,6 +42,16 @@ impl LogsWidget {
             .style(Style::default().fg(Color::DarkGray));
         frame.render_widget(title, info);
 
+        if app.state.has_log_errors {
+            let loading_widget = Paragraph::new(Text::styled(
+                "Something went wrong while fetching logs.",
+                Style::default().fg(Color::White),
+            ))
+            .block(Block::default().padding(Padding::new(1, 1, 0, 0)));
+            frame.render_widget(loading_widget, logs_area);
+            return;
+        }
+
         // it will show loader only on the first call
         if app.state.is_fetching_log_entries {
             let loading_widget = Paragraph::new(Text::styled(

--- a/cli/src/commands/tui/ui/namespace_selection.rs
+++ b/cli/src/commands/tui/ui/namespace_selection.rs
@@ -80,6 +80,7 @@ impl NamespaceSelectionWidget {
                     // to re-trigger the polling
                     app.state.is_fetching_log_entries = true;
                     app.state.start_polling_log_entries = false;
+                    app.state.has_log_errors = false;
                 }
 
                 app.current_screen = CurrentScreen::Main;

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -177,6 +177,8 @@ pub enum GCloudError {
     Io(#[from] ::std::io::Error),
     #[error(transparent)]
     GoogleLogging2Error(#[from] google_logging2::Error),
+    #[error(transparent)]
+    ResponseError(#[from] tonic::Status),
 }
 
 // Secret Extractor Error

--- a/sdk/src/services/gcloud/mod.rs
+++ b/sdk/src/services/gcloud/mod.rs
@@ -183,8 +183,7 @@ impl GCloudClient {
 
         let response = service
             .list_log_entries(Request::new(request))
-            .await
-            .unwrap()
+            .await?
             .into_inner();
 
         Ok(LogEntries {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

Currently TUI breaks if there is an error while fetching the gcloud logs. To avoid that added a handler to handle the logs

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [https://mindvalley.atlassian.net/browse/PXP-604](https://mindvalley.atlassian.net/browse/PXP-604)


<table role="table">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="1680" alt="Screenshot 2023-09-05 at 2 33 50 PM" src="https://github.com/mindvalley/wukong-cli/assets/25294487/da020f05-9ee9-4d1f-aacc-8666eba3ecc6">

</td>
<td>
<img width="1675" alt="Screenshot 2023-09-05 at 2 34 57 PM" src="https://github.com/mindvalley/wukong-cli/assets/25294487/95304071-f5d2-44bc-be2e-3f716f82f92c">

</td>
</tr>
</tbody>
</table>

<!-- ## What's Changed -->

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

<!-- ### Fixed -->
