### PR TITLE
PXP-583: [CLI] New Error Codes handling

### DIFF
--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -35,8 +35,11 @@ pub struct State {
     pub builds: Vec<Build>,
     pub deployments: Vec<Deployment>,
     pub log_entries_hash_map: HashMap<String, LogEntry>,
-    pub has_log_errors: bool,
     pub log_entries_ids: Vec<String>,
+    pub log_entries_error: Option<String>,
+    pub builds_error: Option<String>,
+    pub deployments_error: Option<String>,
+
     // pub log_entries_next_page_token: Option<String>,
     pub last_log_entry_timestamp: Option<String>,
     // ui controls
@@ -106,7 +109,9 @@ impl App {
                 last_log_entry_timestamp: None,
                 log_entries_hash_map: HashMap::new(),
                 log_entries_ids: vec![],
-                has_log_errors: false,
+                log_entries_error: None,
+                builds_error: None,
+                deployments_error: None,
 
                 logs_vertical_scroll_state: ScrollbarState::default(),
                 logs_horizontal_scroll_state: ScrollbarState::default(),

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -190,19 +190,18 @@ async fn get_builds(app: Arc<Mutex<App>>, wk_client: &mut WKClient) -> Result<()
 
     let mut builds = vec![];
 
-  
-              let cd_pipeline_data = match wk_client
-                .fetch_cd_pipeline(&application, &namespace, &version)
-                .await
-            {
-                Ok(resp) => Ok(resp),
-                Err(err) => {
-                    let mut app_ref = app.lock().await;
-                    app_ref.state.builds_error = Some(format!("{err}"));
-                    Err(err)
-                }
-            }?
-            .cd_pipeline;
+    let cd_pipeline_data = match wk_client
+        .fetch_cd_pipeline(&application, &namespace, &version)
+        .await
+    {
+        Ok(resp) => Ok(resp),
+        Err(err) => {
+            let mut app_ref = app.lock().await;
+            app_ref.state.builds_error = Some(format!("{err}"));
+            Err(err)
+        }
+    }?
+    .cd_pipeline;
 
     if let Some(cd_pipeline_data) = cd_pipeline_data {
         builds = cd_pipeline_data
@@ -244,15 +243,15 @@ async fn get_deployments(app: Arc<Mutex<App>>, wk_client: &mut WKClient) -> Resu
 
     drop(app_ref);
 
-  let cd_pipelines_data = match wk_client.fetch_cd_pipelines(&application).await {
-                Ok(resp) => Ok(resp),
-                Err(err) => {
-                    let mut app_ref = app.lock().await;
-                    app_ref.state.deployments_error = Some(format!("{err}"));
-                    Err(err)
-                }
-            }?
-            .cd_pipelines;
+    let cd_pipelines_data = match wk_client.fetch_cd_pipelines(&application).await {
+        Ok(resp) => Ok(resp),
+        Err(err) => {
+            let mut app_ref = app.lock().await;
+            app_ref.state.deployments_error = Some(format!("{err}"));
+            Err(err)
+        }
+    }?
+    .cd_pipelines;
 
     let mut app_ref = app.lock().await;
     app_ref.state.deployments = cd_pipelines_data
@@ -301,8 +300,8 @@ async fn get_gcloud_logs(app: Arc<Mutex<App>>, wk_client: &mut WKClient) -> Resu
 
     if let Some(namespace) = namespace {
         if let Some(version) = version {
-          let application_resp = match wk_client
-                .fetch_application_with_k8s_cluster(&application, &namespace, version)
+            let application_resp = match wk_client
+                .fetch_application_with_k8s_cluster(&application, &namespace, &version)
                 .await
             {
                 Ok(resp) => Ok(resp),

--- a/cli/src/commands/tui/ui/builds.rs
+++ b/cli/src/commands/tui/ui/builds.rs
@@ -19,6 +19,14 @@ impl BuildsWidget {
             .padding(Padding::new(1, 1, 0, 0))
             .style(Style::default().fg(Color::LightYellow));
 
+        if let Some(ref error) = app.state.builds_error {
+            let error_widget =
+                Paragraph::new(Text::styled(error, Style::default().fg(Color::White)))
+                    .block(builds_block);
+            frame.render_widget(error_widget, rect);
+            return;
+        }
+
         if app.state.is_fetching_builds {
             let loading_widget = Paragraph::new(Text::styled(
                 "Loading...",

--- a/cli/src/commands/tui/ui/deployment.rs
+++ b/cli/src/commands/tui/ui/deployment.rs
@@ -19,6 +19,14 @@ impl DeploymentWidget {
             .borders(Borders::ALL)
             .style(Style::default().fg(Color::LightBlue));
 
+        if let Some(ref error) = app.state.deployments_error {
+            let error_widget =
+                Paragraph::new(Text::styled(error, Style::default().fg(Color::White)))
+                    .block(deployments_block.padding(Padding::new(1, 1, 0, 0)));
+            frame.render_widget(error_widget, rect);
+            return;
+        }
+
         if app.state.is_fetching_deployments {
             let loading_widget = Paragraph::new(Text::styled(
                 "Loading...",

--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -42,13 +42,11 @@ impl LogsWidget {
             .style(Style::default().fg(Color::DarkGray));
         frame.render_widget(title, info);
 
-        if app.state.has_log_errors {
-            let loading_widget = Paragraph::new(Text::styled(
-                "Something went wrong while fetching logs.",
-                Style::default().fg(Color::White),
-            ))
-            .block(Block::default().padding(Padding::new(1, 1, 0, 0)));
-            frame.render_widget(loading_widget, logs_area);
+        if let Some(ref error) = app.state.log_entries_error {
+            let error_widget =
+                Paragraph::new(Text::styled(error, Style::default().fg(Color::White)))
+                    .block(Block::default().padding(Padding::new(1, 1, 0, 0)));
+            frame.render_widget(error_widget, logs_area);
             return;
         }
 

--- a/cli/src/commands/tui/ui/namespace_selection.rs
+++ b/cli/src/commands/tui/ui/namespace_selection.rs
@@ -72,8 +72,6 @@ impl NamespaceSelectionWidget {
                     if current_namespace != selected {
                         fetch_and_reset_polling(app, selected.to_string()).await;
                     }
-                } else {
-                    fetch_and_reset_polling(app, selected.to_string()).await;
                 }
 
                 set_current_screen_to_main(app)
@@ -90,7 +88,7 @@ async fn fetch_and_reset_polling(app: &mut App, selected_version: String) {
 
     app.state.is_fetching_log_entries = true;
     app.state.start_polling_log_entries = false;
-    
+
     // reset error state
     app.state.log_entries_error = None;
     app.state.has_log_errors = false;

--- a/cli/src/commands/tui/ui/namespace_selection.rs
+++ b/cli/src/commands/tui/ui/namespace_selection.rs
@@ -80,7 +80,8 @@ impl NamespaceSelectionWidget {
                     // to re-trigger the polling
                     app.state.is_fetching_log_entries = true;
                     app.state.start_polling_log_entries = false;
-                    app.state.has_log_errors = false;
+                    // reset error state
+                    app.state.log_entries_error = None;
                 }
 
                 app.current_screen = CurrentScreen::Main;

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -35,6 +35,8 @@ pub enum WKCliError {
     #[error(transparent)]
     DeploymentError(#[from] DeploymentError),
     #[error(transparent)]
+    PipelineError(#[from] PipelineError),
+    #[error(transparent)]
     DevConfigError(#[from] DevConfigError),
     #[error(transparent)]
     ApplicationInstanceError(#[from] ApplicationInstanceError),
@@ -104,6 +106,12 @@ pub enum ConfigError {
     SerializeTomlError(#[source] toml::ser::Error),
     #[error(transparent)]
     Io(#[from] ::std::io::Error),
+}
+
+#[derive(Debug, ThisError)]
+pub enum PipelineError {
+    #[error("Could not find the application associated with this Git repo.\n\tEither you're not in the correct working folder for your application, or there's a misconfiguration.")]
+    CIStatusApplicationNotFound,
 }
 
 #[derive(Debug, ThisError)]

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -82,6 +82,8 @@ pub enum APIError {
     NamespaceNotFound,
     #[error("Version not found.")]
     VersionNotFound,
+    #[error("Build not found.")]
+    BuildNotFound,
 }
 
 #[derive(Debug, ThisError)]

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -66,22 +66,22 @@ pub enum APIError {
     MissingResponseData,
     #[error("The selected build number is the same as the current deployed version. So there is no changelog.")]
     ChangelogComparingSameBuild,
-    #[error("Unable to get pipelines for application `{application}`.")]
-    UnableToGetPipelines { application: String },
-    #[error("Unable to get pipeline `{pipeline}`.")]
-    UnableToGetPipeline { pipeline: String },
+    #[error("Unable to get pipelines.")]
+    UnableToGetPipelines,
+    #[error("Unable to get pipeline.")]
+    UnableToGetPipeline,
     #[error("Could not find the application associated with this Git repo.\n\tEither you're not in the correct working folder for your application, or there's a misconfiguration.")]
     CIStatusApplicationNotFound,
-    #[error("Application `{application}` not found.")]
-    ApplicationNotFound { application: String },
-    #[error("Unable to determine the changelog for {build}.")]
-    UnableToDetermineChangelog { build: String },
+    #[error("Application not found.")]
+    ApplicationNotFound,
+    #[error("Unable to determine the changelog for this build.")]
+    UnableToDetermineChangelog,
     #[error("Cannot submit this deployment request, since there is another running deployment with the same arguments is running on Spinnaker.\nYou can wait a few minutes and submit the deployment again.")]
     DuplicatedDeployment,
-    #[error("Namespace `{namespace}` not found.")]
-    NamespaceNotFound { namespace: String },
-    #[error("Version `{version}` not found.")]
-    VersionNotFound { version: String },
+    #[error("Namespace not found.")]
+    NamespaceNotFound,
+    #[error("Version not found.")]
+    VersionNotFound,
 }
 
 #[derive(Debug, ThisError)]

--- a/sdk/src/graphql/application.rs
+++ b/sdk/src/graphql/application.rs
@@ -29,7 +29,7 @@ mod test {
     use crate::{ApiChannel, WKClient, WKConfig};
     use httpmock::prelude::*;
 
-    fn setup_stable_wk_client(api_url: &str) -> WKClient {
+    fn setup_wk_client(api_url: &str) -> WKClient {
         WKClient::new(WKConfig {
             api_url: api_url.to_string(),
             access_token: "test_access_token".to_string(),
@@ -37,18 +37,10 @@ mod test {
         })
     }
 
-    fn setup_canary_wk_client(api_url: &str) -> WKClient {
-        WKClient::new(WKConfig {
-            api_url: api_url.to_string(),
-            access_token: "test_access_token".to_string(),
-            channel: ApiChannel::Canary,
-        })
-    }
-
     #[tokio::test]
     async fn test_fetch_application_success_should_return_correct_application_info() {
         let server = MockServer::start();
-        let wk_clinet = setup_stable_wk_client(&server.base_url());
+        let wk_clinet = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -102,7 +94,7 @@ mod test {
     #[tokio::test]
     async fn test_fetch_application_list_success_should_return_application_list() {
         let server = MockServer::start();
-        let wk_clinet = setup_stable_wk_client(&server.base_url());
+        let wk_clinet = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {

--- a/sdk/src/graphql/application.rs
+++ b/sdk/src/graphql/application.rs
@@ -29,7 +29,7 @@ mod test {
     use crate::{ApiChannel, WKClient, WKConfig};
     use httpmock::prelude::*;
 
-    fn setup_wk_client(api_url: &str) -> WKClient {
+    fn setup_stable_wk_client(api_url: &str) -> WKClient {
         WKClient::new(WKConfig {
             api_url: api_url.to_string(),
             access_token: "test_access_token".to_string(),
@@ -37,10 +37,18 @@ mod test {
         })
     }
 
+    fn setup_canary_wk_client(api_url: &str) -> WKClient {
+        WKClient::new(WKConfig {
+            api_url: api_url.to_string(),
+            access_token: "test_access_token".to_string(),
+            channel: ApiChannel::Canary,
+        })
+    }
+
     #[tokio::test]
     async fn test_fetch_application_success_should_return_correct_application_info() {
         let server = MockServer::start();
-        let wk_clinet = setup_wk_client(&server.base_url());
+        let wk_clinet = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -94,7 +102,7 @@ mod test {
     #[tokio::test]
     async fn test_fetch_application_list_success_should_return_application_list() {
         let server = MockServer::start();
-        let wk_clinet = setup_wk_client(&server.base_url());
+        let wk_clinet = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {

--- a/sdk/src/graphql/changelog.rs
+++ b/sdk/src/graphql/changelog.rs
@@ -16,7 +16,7 @@ mod test {
     };
     use httpmock::prelude::*;
 
-    fn setup_wk_client(api_url: &str) -> WKClient {
+    fn setup_stable_wk_client(api_url: &str) -> WKClient {
         WKClient::new(WKConfig {
             api_url: api_url.to_string(),
             access_token: "test_access_token".to_string(),
@@ -24,10 +24,18 @@ mod test {
         })
     }
 
+    fn setup_canary_wk_client(api_url: &str) -> WKClient {
+        WKClient::new(WKConfig {
+            api_url: api_url.to_string(),
+            access_token: "test_access_token".to_string(),
+            channel: ApiChannel::Canary,
+        })
+    }
+
     #[tokio::test]
     async fn test_fetch_changelog_list_success_should_return_changelog_list() {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -71,7 +79,7 @@ mod test {
     async fn test_fetch_changelog_list_failed_with_application_not_found_error_should_return_application_not_found_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -119,7 +127,7 @@ mod test {
     async fn test_fetch_changelog_list_failed_with_unable_to_determine_changelog_error_should_return_unable_to_determine_changelog_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -171,7 +179,7 @@ mod test {
     async fn test_fetch_changelog_list_failed_with_comparing_same_build_error_should_return_changelog_comparing_same_build_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {

--- a/sdk/src/graphql/changelog.rs
+++ b/sdk/src/graphql/changelog.rs
@@ -16,7 +16,7 @@ mod test {
     };
     use httpmock::prelude::*;
 
-    fn setup_stable_wk_client(api_url: &str) -> WKClient {
+    fn setup_wk_client(api_url: &str) -> WKClient {
         WKClient::new(WKConfig {
             api_url: api_url.to_string(),
             access_token: "test_access_token".to_string(),
@@ -24,18 +24,10 @@ mod test {
         })
     }
 
-    fn setup_canary_wk_client(api_url: &str) -> WKClient {
-        WKClient::new(WKConfig {
-            api_url: api_url.to_string(),
-            access_token: "test_access_token".to_string(),
-            channel: ApiChannel::Canary,
-        })
-    }
-
     #[tokio::test]
     async fn test_fetch_changelog_list_success_should_return_changelog_list() {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -79,7 +71,7 @@ mod test {
     async fn test_fetch_changelog_list_failed_with_application_not_found_error_should_return_application_not_found_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -127,7 +119,7 @@ mod test {
     async fn test_fetch_changelog_list_failed_with_unable_to_determine_changelog_error_should_return_unable_to_determine_changelog_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -179,7 +171,7 @@ mod test {
     async fn test_fetch_changelog_list_failed_with_comparing_same_build_error_should_return_changelog_comparing_same_build_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {

--- a/sdk/src/graphql/changelog.rs
+++ b/sdk/src/graphql/changelog.rs
@@ -108,16 +108,11 @@ mod test {
 
         let error = response.unwrap_err();
         match &error {
-            WKError::APIError(APIError::ApplicationNotFound { application }) => {
-                assert_eq!(application, "invalid-application");
-            }
+            WKError::APIError(APIError::ApplicationNotFound) => {}
             _ => panic!("it should be returning APIError::ApplicationNotFound"),
         };
 
-        assert_eq!(
-            format!("{error}"),
-            "Application `invalid-application` not found."
-        );
+        assert_eq!(format!("{error}"), "Application not found.");
     }
 
     #[tokio::test]
@@ -162,18 +157,13 @@ mod test {
 
         let error = response.unwrap_err();
         match &error {
-            WKError::APIError(APIError::UnableToDetermineChangelog { build }) => {
-                assert_eq!(build, invalid_build_number);
-            }
+            WKError::APIError(APIError::UnableToDetermineChangelog) => {}
             _ => panic!("it should be returning APIError::UnableToDetermineChangelog"),
         };
 
         assert_eq!(
             format!("{error}"),
-            format!(
-                "Unable to determine the changelog for {}.",
-                invalid_build_number
-            )
+            format!("Unable to determine the changelog for this build.",)
         );
     }
 

--- a/sdk/src/graphql/deployment.rs
+++ b/sdk/src/graphql/deployment.rs
@@ -42,7 +42,7 @@ mod test {
     use base64::Engine;
     use httpmock::prelude::*;
 
-    fn setup_wk_client(api_url: &str) -> WKClient {
+    fn setup_stable_wk_client(api_url: &str) -> WKClient {
         WKClient::new(WKConfig {
             api_url: api_url.to_string(),
             access_token: "test_access_token".to_string(),
@@ -50,10 +50,18 @@ mod test {
         })
     }
 
+    fn setup_canary_wk_client(api_url: &str) -> WKClient {
+        WKClient::new(WKConfig {
+            api_url: api_url.to_string(),
+            access_token: "test_access_token".to_string(),
+            channel: ApiChannel::Canary,
+        })
+    }
+
     #[tokio::test]
     async fn test_fetch_cd_pipeline_list_success_should_return_cd_pipeline_list() {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -103,7 +111,7 @@ mod test {
     async fn test_fetch_cd_pipeline_list_failed_with_application_not_found_error_should_return_application_not_found_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -148,7 +156,7 @@ mod test {
     #[tokio::test]
     async fn test_fetch_cd_pipeline_for_rollback_success_should_return_cd_pipeline() {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -195,7 +203,7 @@ mod test {
     #[tokio::test]
     async fn test_execute_cd_pipeline_success_should_return_deployment_url() {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -238,7 +246,7 @@ mod test {
     async fn test_execute_cd_pipeline_list_failed_with_deploy_for_this_build_is_currently_running_error_should_return_duplicate_deployment_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {

--- a/sdk/src/graphql/deployment.rs
+++ b/sdk/src/graphql/deployment.rs
@@ -138,16 +138,11 @@ mod test {
 
         let error = response.unwrap_err();
         match &error {
-            WKError::APIError(APIError::ApplicationNotFound { application }) => {
-                assert_eq!(application, "invalid-application");
-            }
+            WKError::APIError(APIError::ApplicationNotFound) => {}
             _ => panic!("it should be returning APIError::ApplicationNotFound",),
         };
 
-        assert_eq!(
-            format!("{error}"),
-            "Application `invalid-application` not found."
-        );
+        assert_eq!(format!("{error}"), "Application not found.");
     }
 
     #[tokio::test]

--- a/sdk/src/graphql/deployment.rs
+++ b/sdk/src/graphql/deployment.rs
@@ -42,7 +42,7 @@ mod test {
     use base64::Engine;
     use httpmock::prelude::*;
 
-    fn setup_stable_wk_client(api_url: &str) -> WKClient {
+    fn setup_wk_client(api_url: &str) -> WKClient {
         WKClient::new(WKConfig {
             api_url: api_url.to_string(),
             access_token: "test_access_token".to_string(),
@@ -50,18 +50,10 @@ mod test {
         })
     }
 
-    fn setup_canary_wk_client(api_url: &str) -> WKClient {
-        WKClient::new(WKConfig {
-            api_url: api_url.to_string(),
-            access_token: "test_access_token".to_string(),
-            channel: ApiChannel::Canary,
-        })
-    }
-
     #[tokio::test]
     async fn test_fetch_cd_pipeline_list_success_should_return_cd_pipeline_list() {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -111,7 +103,7 @@ mod test {
     async fn test_fetch_cd_pipeline_list_failed_with_application_not_found_error_should_return_application_not_found_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -156,7 +148,7 @@ mod test {
     #[tokio::test]
     async fn test_fetch_cd_pipeline_for_rollback_success_should_return_cd_pipeline() {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -203,7 +195,7 @@ mod test {
     #[tokio::test]
     async fn test_execute_cd_pipeline_success_should_return_deployment_url() {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -246,7 +238,7 @@ mod test {
     async fn test_execute_cd_pipeline_list_failed_with_deploy_for_this_build_is_currently_running_error_should_return_duplicate_deployment_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {

--- a/sdk/src/graphql/deployment_github.rs
+++ b/sdk/src/graphql/deployment_github.rs
@@ -16,7 +16,7 @@ mod test {
     };
     use httpmock::prelude::*;
 
-    fn setup_stable_wk_client(api_url: &str) -> WKClient {
+    fn setup_wk_client(api_url: &str) -> WKClient {
         WKClient::new(WKConfig {
             api_url: api_url.to_string(),
             access_token: "test_access_token".to_string(),
@@ -24,18 +24,10 @@ mod test {
         })
     }
 
-    fn setup_canary_wk_client(api_url: &str) -> WKClient {
-        WKClient::new(WKConfig {
-            api_url: api_url.to_string(),
-            access_token: "test_access_token".to_string(),
-            channel: ApiChannel::Canary,
-        })
-    }
-
     #[tokio::test]
     async fn test_fetch_cd_pipeline_github_success_should_return_pipeline_with_github_builds() {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -99,7 +91,7 @@ mod test {
     async fn test_fetch_cd_pipeline_github_failed_with_github_workflow_not_found_error_should_return_unable_to_get_pipelines_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {

--- a/sdk/src/graphql/deployment_github.rs
+++ b/sdk/src/graphql/deployment_github.rs
@@ -16,7 +16,7 @@ mod test {
     };
     use httpmock::prelude::*;
 
-    fn setup_wk_client(api_url: &str) -> WKClient {
+    fn setup_stable_wk_client(api_url: &str) -> WKClient {
         WKClient::new(WKConfig {
             api_url: api_url.to_string(),
             access_token: "test_access_token".to_string(),
@@ -24,10 +24,18 @@ mod test {
         })
     }
 
+    fn setup_canary_wk_client(api_url: &str) -> WKClient {
+        WKClient::new(WKConfig {
+            api_url: api_url.to_string(),
+            access_token: "test_access_token".to_string(),
+            channel: ApiChannel::Canary,
+        })
+    }
+
     #[tokio::test]
     async fn test_fetch_cd_pipeline_github_success_should_return_pipeline_with_github_builds() {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -91,7 +99,7 @@ mod test {
     async fn test_fetch_cd_pipeline_github_failed_with_github_workflow_not_found_error_should_return_unable_to_get_pipelines_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {

--- a/sdk/src/graphql/kubernetes.rs
+++ b/sdk/src/graphql/kubernetes.rs
@@ -139,11 +139,8 @@ mod test {
         assert!(response.is_err());
 
         match response.as_ref().unwrap_err() {
-            WKError::APIError(APIError::ResponseError { code, message }) => {
-                assert_eq!(code, "Unauthorized");
-                assert_eq!(message, "Unauthorized")
-            }
-            _ => panic!("it should be returning ResponseError"),
+            WKError::APIError(APIError::UnAuthorized) => {}
+            _ => panic!("it should be returning APIError"),
         }
     }
 

--- a/sdk/src/graphql/kubernetes.rs
+++ b/sdk/src/graphql/kubernetes.rs
@@ -48,7 +48,7 @@ mod test {
     };
     use httpmock::prelude::*;
 
-    fn setup_stable_wk_client(api_url: &str) -> WKClient {
+    fn setup_wk_client(api_url: &str) -> WKClient {
         WKClient::new(WKConfig {
             api_url: api_url.to_string(),
             access_token: "test_access_token".to_string(),
@@ -56,18 +56,10 @@ mod test {
         })
     }
 
-    fn setup_canary_wk_client(api_url: &str) -> WKClient {
-        WKClient::new(WKConfig {
-            api_url: api_url.to_string(),
-            access_token: "test_access_token".to_string(),
-            channel: ApiChannel::Canary,
-        })
-    }
-
     #[tokio::test]
     async fn test_fetch_kubernetes_pods_list_success_should_return_kubernetes_pods_list() {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -111,7 +103,7 @@ mod test {
     async fn test_fetch_kubernetes_pods_list_failed_with_unautorized_error_should_return_response_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -155,7 +147,7 @@ mod test {
     #[tokio::test]
     async fn test_fetch_is_authorized_success_should_return_boolean_value() {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {

--- a/sdk/src/graphql/kubernetes.rs
+++ b/sdk/src/graphql/kubernetes.rs
@@ -48,7 +48,7 @@ mod test {
     };
     use httpmock::prelude::*;
 
-    fn setup_wk_client(api_url: &str) -> WKClient {
+    fn setup_stable_wk_client(api_url: &str) -> WKClient {
         WKClient::new(WKConfig {
             api_url: api_url.to_string(),
             access_token: "test_access_token".to_string(),
@@ -56,10 +56,18 @@ mod test {
         })
     }
 
+    fn setup_canary_wk_client(api_url: &str) -> WKClient {
+        WKClient::new(WKConfig {
+            api_url: api_url.to_string(),
+            access_token: "test_access_token".to_string(),
+            channel: ApiChannel::Canary,
+        })
+    }
+
     #[tokio::test]
     async fn test_fetch_kubernetes_pods_list_success_should_return_kubernetes_pods_list() {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -103,7 +111,7 @@ mod test {
     async fn test_fetch_kubernetes_pods_list_failed_with_unautorized_error_should_return_response_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -147,7 +155,7 @@ mod test {
     #[tokio::test]
     async fn test_fetch_is_authorized_success_should_return_boolean_value() {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {

--- a/sdk/src/graphql/mod.rs
+++ b/sdk/src/graphql/mod.rs
@@ -686,7 +686,7 @@ impl ErrorHandler for CanaryErrorHandler {
             "changelog_unable_to_determine" => APIError::UnableToDetermineChangelog,
             "changelog_same_commit" => APIError::ChangelogComparingSameBuild,
 
-            // "application_k8s_cluster_not_found" => {]
+            // "application_k8s_cluster_not_found" => {}
             // "application_spinnaker_pipeline_not_found" => {}
             // "application_config_error" => {}
             // "k8s_destroy_livebook_failed" => {}

--- a/sdk/src/graphql/mod.rs
+++ b/sdk/src/graphql/mod.rs
@@ -676,8 +676,86 @@ impl ErrorHandler for DefaultErrorHandler {
     }
 }
 impl ErrorHandler for CanaryErrorHandler {
-    fn handle_error(&self, _error: &graphql_client::Error) -> APIError {
-        todo!()
+    fn handle_error(&self, error: &graphql_client::Error) -> APIError {
+        let error_code = self.extract_error_code(error);
+        match error_code {
+            "application_not_found" => APIError::ApplicationNotFound,
+            "application_namespace_not_found" => APIError::NamespaceNotFound,
+            "application_version_not_found" => APIError::VersionNotFound,
+            // "application_k8s_cluster_not_found" => {]
+            // "application_spinnaker_pipeline_not_found" => {}
+            // "application_config_error" => {}
+
+            // authentication
+            "unauthenticated" | "invalid_token" => APIError::UnAuthenticated,
+            "unauthorized" => APIError::UnAuthorized,
+
+            // pipeline
+            "pipeline_not_configured" | "pipeline_not_found" => APIError::UnableToGetPipeline,
+            // "pipeline_deployment_in_progress" => {}
+            // "pipeline_changelogs_not_provided" => {}
+
+            // k8s
+            // "k8s_destroy_livebook_failed" => {}
+            // "k8s_cluster_context_missing" => {}
+            // "k8s_kubeconfig_missing" => {}
+            // "k8s_service_not_found_or_deleted" => {}
+            // "k8s_ingress_not_found_or_deleted" => {}
+            // "k8s_issuer_not_found_or_deleted" => {}
+            // "k8s_pod_not_found_or_deleted" => {}
+            // "k8s_operation_timed_out" => {}
+            // "k8s_ingress_ip_not_found" => {}
+            // "k8s_cluster_ip_not_found" => {}
+            // "k8s_context_not_found" => {}
+            // "k8s_kubeconfig_not_found" => {}
+
+            // spinnaker
+            // "spinnaker_x509_failure" => {}
+            // "spinnaker_invalid_domain" => {}
+            // "spinnaker_timeout" => {}
+            // "spinnaker_error" => {}
+
+            // jenkins
+            // "jenkins_build_not_found" => {}
+            // "jenkins_invalid_domain" => {}
+            // "jenkins_timeout" => {}
+            // "jenkins_pipeline_not_found" => {}
+            // "jenkins_commit_id_not_found" => {}
+
+            // github
+            // "github_repo_name_not_found" => {}
+            // "github_error" => {}
+            // "github_invalid_domain" => {}
+            // "github_timeout" => {}
+            // "github_pr_not_found" => {}
+            // "github_ref_not_found" => {}
+            // "github_commit_history_not_found" => {}
+            // "github_workflow_not_found" => {}
+
+            // slack
+            // "slack_webhook_not_configured" => {}
+
+            // changelog
+            "changelog_unable_to_determine" => APIError::UnableToDetermineChangelog,
+
+            "unable_to_get_pipelines" => APIError::UnableToGetPipelines,
+            "unable_to_get_pipeline" => APIError::UnableToGetPipeline,
+            // "application_not_found" => APIError::ApplicationNotFound,
+            "application_config_not_defined" => APIError::ApplicationNotFound,
+            "unable_to_determine_changelog" => APIError::UnableToDetermineChangelog,
+            "comparing_same_build" => APIError::ChangelogComparingSameBuild,
+            "deploy_for_this_build_is_currently_running" => APIError::DuplicatedDeployment,
+            "k8s_cluster_namespace_config_not_defined" => APIError::NamespaceNotFound,
+            "k8s_cluster_version_config_not_defined" => APIError::VersionNotFound,
+            // "unauthorized" => APIError::ResponseError {
+            //     code: error_code.to_string(),
+            //     message: error_code.to_string(),
+            // },
+            _ => APIError::ResponseError {
+                code: error_code.to_string(),
+                message: format!("{:?}", error),
+            },
+        }
     }
 
     fn extract_error_code<'a>(&'a self, error: &'a graphql_client::Error) -> &'a str {

--- a/sdk/src/graphql/mod.rs
+++ b/sdk/src/graphql/mod.rs
@@ -671,9 +671,6 @@ impl ErrorHandler for CanaryErrorHandler {
             "application_not_found" => APIError::ApplicationNotFound,
             "application_namespace_not_found" => APIError::NamespaceNotFound,
             "application_version_not_found" => APIError::VersionNotFound,
-            // "application_k8s_cluster_not_found" => {]
-            // "application_spinnaker_pipeline_not_found" => {}
-            // "application_config_error" => {}
 
             // authentication
             "unauthenticated" | "invalid_token" => APIError::UnAuthenticated,
@@ -683,8 +680,15 @@ impl ErrorHandler for CanaryErrorHandler {
             "pipeline_not_configured" | "pipeline_not_found" => APIError::UnableToGetPipeline,
             "pipeline_deployment_in_progress" => APIError::DuplicatedDeployment,
             // "pipeline_changelogs_not_provided" => {}
+            "jenkins_build_not_found" => APIError::BuildNotFound,
+            "jenkins_pipeline_not_found" => APIError::UnableToGetPipeline,
 
-            // k8s
+            "changelog_unable_to_determine" => APIError::UnableToDetermineChangelog,
+            "changelog_same_commit" => APIError::ChangelogComparingSameBuild,
+
+            // "application_k8s_cluster_not_found" => {]
+            // "application_spinnaker_pipeline_not_found" => {}
+            // "application_config_error" => {}
             // "k8s_destroy_livebook_failed" => {}
             // "k8s_cluster_context_missing" => {}
             // "k8s_kubeconfig_missing" => {}
@@ -697,37 +701,19 @@ impl ErrorHandler for CanaryErrorHandler {
             // "k8s_cluster_ip_not_found" => {}
             // "k8s_context_not_found" => {}
             // "k8s_kubeconfig_not_found" => {}
-
-            // spinnaker
             // "spinnaker_x509_failure" => {}
             // "spinnaker_invalid_domain" => {}
-            // "spinnaker_timeout" => {}
             // "spinnaker_error" => {}
-
-            // jenkins
-            "jenkins_build_not_found" => APIError::BuildNotFound,
             // "jenkins_invalid_domain" => {}
-            // "jenkins_timeout" => {}
-            "jenkins_pipeline_not_found" => APIError::UnableToGetPipeline,
             // "jenkins_commit_id_not_found" => {}
-
-            // github
             // "github_repo_name_not_found" => {}
             // "github_error" => {}
             // "github_invalid_domain" => {}
-            // "github_timeout" => {}
             // "github_pr_not_found" => {}
             // "github_ref_not_found" => {}
             // "github_commit_history_not_found" => {}
             // "github_workflow_not_found" => {}
-
-            // slack
             // "slack_webhook_not_configured" => {}
-
-            // changelog
-            "changelog_unable_to_determine" => APIError::UnableToDetermineChangelog,
-            "changelog_same_commit" => APIError::ChangelogComparingSameBuild,
-
             _ => APIError::ResponseError {
                 code: original_error_code.to_string(),
                 message: format!("{error}"),

--- a/sdk/src/graphql/pipeline.rs
+++ b/sdk/src/graphql/pipeline.rs
@@ -131,16 +131,11 @@ mod test {
 
         let error = response.unwrap_err();
         match &error {
-            WKError::APIError(APIError::UnableToGetPipelines { application }) => {
-                assert_eq!(application, "invalid-application");
-            }
+            WKError::APIError(APIError::UnableToGetPipelines) => {}
             _ => panic!("it should be returning APIError::UnableToGetPipelines"),
         };
 
-        assert_eq!(
-            format!("{error}"),
-            "Unable to get pipelines for application `invalid-application`."
-        );
+        assert_eq!(format!("{error}"), "Unable to get pipelines.");
     }
 
     #[tokio::test]
@@ -228,16 +223,11 @@ mod test {
 
         let error = response.unwrap_err();
         match &error {
-            WKError::APIError(APIError::UnableToGetPipeline { pipeline }) => {
-                assert_eq!(pipeline, "invalid-pipeline");
-            }
+            WKError::APIError(APIError::UnableToGetPipeline) => {}
             _ => panic!("it should be returning APIError::UnableToGetPipeline"),
         };
 
-        assert_eq!(
-            format!("{error}"),
-            "Unable to get pipeline `invalid-pipeline`."
-        );
+        assert_eq!(format!("{error}"), "Unable to get pipeline.");
     }
 
     #[tokio::test]
@@ -349,16 +339,11 @@ mod test {
 
         let error = response.unwrap_err();
         match &error {
-            WKError::APIError(APIError::UnableToGetPipeline { pipeline }) => {
-                assert_eq!(pipeline, "invalid-pipeline");
-            }
+            WKError::APIError(APIError::UnableToGetPipeline) => {}
             _ => panic!("it should be returning APIError::UnableToGetPipeline"),
         };
 
-        assert_eq!(
-            format!("{error}"),
-            "Unable to get pipeline `invalid-pipeline`."
-        );
+        assert_eq!(format!("{error}"), "Unable to get pipeline.");
     }
 
     #[tokio::test]

--- a/sdk/src/graphql/pipeline.rs
+++ b/sdk/src/graphql/pipeline.rs
@@ -41,7 +41,7 @@ mod test {
     };
     use httpmock::prelude::*;
 
-    fn setup_stable_wk_client(api_url: &str) -> WKClient {
+    fn setup_wk_client(api_url: &str) -> WKClient {
         WKClient::new(WKConfig {
             api_url: api_url.to_string(),
             access_token: "test_access_token".to_string(),
@@ -49,18 +49,10 @@ mod test {
         })
     }
 
-    fn setup_canary_wk_client(api_url: &str) -> WKClient {
-        WKClient::new(WKConfig {
-            api_url: api_url.to_string(),
-            access_token: "test_access_token".to_string(),
-            channel: ApiChannel::Canary,
-        })
-    }
-
     #[tokio::test]
     async fn test_fetch_pipeline_list_success_should_return_pipeline_list() {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -104,7 +96,7 @@ mod test {
     async fn test_fetch_pipeline_list_failed_with_unable_to_get_pipelines_error_should_return_unable_to_get_pipelines_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -149,7 +141,7 @@ mod test {
     #[tokio::test]
     async fn test_fetch_pipeline_success_should_return_pipeline() {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -196,7 +188,7 @@ mod test {
     async fn test_fetch_pipeline_failed_with_unable_to_get_pipeline_error_should_return_unable_to_get_pipeline_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -241,7 +233,7 @@ mod test {
     #[tokio::test]
     async fn test_fetch_multi_branch_pipeline_success_should_return_that_pipeline() {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -310,7 +302,7 @@ mod test {
     async fn test_fetch_multi_branch_pipeline_with_unable_to_get_pipeline_error_should_return_unable_to_get_pipeline_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -357,7 +349,7 @@ mod test {
     #[tokio::test]
     async fn test_fetch_ci_status_success_should_return_ci_status() {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -410,7 +402,7 @@ mod test {
     async fn test_fetch_ci_status_failed_with_application_not_found_error_should_return_ci_status_application_not_found_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -458,7 +450,7 @@ mod test {
     async fn test_fetch_ci_status_failed_with_no_builds_associated_with_this_branch_error_should_return_build_not_build(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_stable_wk_client(&server.base_url());
+        let wk_client = setup_wk_client(&server.base_url());
 
         let api_resp = r#"
 {

--- a/sdk/src/graphql/pipeline.rs
+++ b/sdk/src/graphql/pipeline.rs
@@ -443,14 +443,11 @@ mod test {
             WKError::APIError(APIError::CIStatusApplicationNotFound)
         );
 
-        assert_eq!(
-            format!("{error}"),
-            "Could not find the application associated with this Git repo.\n\tEither you're not in the correct working folder for your application, or there's a misconfiguration."
-        );
+        assert_eq!(format!("{error}"), "Application not found.");
     }
 
     #[tokio::test]
-    async fn test_fetch_ci_status_failed_with_no_builds_associated_with_this_branch_error_should_return_ok_response(
+    async fn test_fetch_ci_status_failed_with_no_builds_associated_with_this_branch_error_should_return_build_not_build(
     ) {
         let server = MockServer::start();
         let wk_client = setup_wk_client(&server.base_url());
@@ -488,8 +485,11 @@ mod test {
             .await;
 
         mock.assert();
-        assert!(response.is_ok());
-        let ci_status = response.unwrap().ci_status;
-        assert!(ci_status.is_none());
+        assert!(response.is_err());
+
+        let error = response.unwrap_err();
+        matches!(error, WKError::APIError(APIError::BuildNotFound));
+
+        assert_eq!(format!("{error}"), "Build not found.");
     }
 }

--- a/sdk/src/graphql/pipeline.rs
+++ b/sdk/src/graphql/pipeline.rs
@@ -41,7 +41,7 @@ mod test {
     };
     use httpmock::prelude::*;
 
-    fn setup_wk_client(api_url: &str) -> WKClient {
+    fn setup_stable_wk_client(api_url: &str) -> WKClient {
         WKClient::new(WKConfig {
             api_url: api_url.to_string(),
             access_token: "test_access_token".to_string(),
@@ -49,10 +49,18 @@ mod test {
         })
     }
 
+    fn setup_canary_wk_client(api_url: &str) -> WKClient {
+        WKClient::new(WKConfig {
+            api_url: api_url.to_string(),
+            access_token: "test_access_token".to_string(),
+            channel: ApiChannel::Canary,
+        })
+    }
+
     #[tokio::test]
     async fn test_fetch_pipeline_list_success_should_return_pipeline_list() {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -96,7 +104,7 @@ mod test {
     async fn test_fetch_pipeline_list_failed_with_unable_to_get_pipelines_error_should_return_unable_to_get_pipelines_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -141,7 +149,7 @@ mod test {
     #[tokio::test]
     async fn test_fetch_pipeline_success_should_return_pipeline() {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -188,7 +196,7 @@ mod test {
     async fn test_fetch_pipeline_failed_with_unable_to_get_pipeline_error_should_return_unable_to_get_pipeline_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -233,7 +241,7 @@ mod test {
     #[tokio::test]
     async fn test_fetch_multi_branch_pipeline_success_should_return_that_pipeline() {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -302,7 +310,7 @@ mod test {
     async fn test_fetch_multi_branch_pipeline_with_unable_to_get_pipeline_error_should_return_unable_to_get_pipeline_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -349,7 +357,7 @@ mod test {
     #[tokio::test]
     async fn test_fetch_ci_status_success_should_return_ci_status() {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -402,7 +410,7 @@ mod test {
     async fn test_fetch_ci_status_failed_with_application_not_found_error_should_return_ci_status_application_not_found_error(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {
@@ -450,7 +458,7 @@ mod test {
     async fn test_fetch_ci_status_failed_with_no_builds_associated_with_this_branch_error_should_return_build_not_build(
     ) {
         let server = MockServer::start();
-        let wk_client = setup_wk_client(&server.base_url());
+        let wk_client = setup_stable_wk_client(&server.base_url());
 
         let api_resp = r#"
 {

--- a/sdk/src/services/gcloud/api/google.api.rs
+++ b/sdk/src/services/gcloud/api/google.api.rs
@@ -884,6 +884,19 @@ pub enum FieldBehavior {
     /// a non-empty value will be returned. The user will not be aware of what
     /// non-empty value to expect.
     NonEmptyDefault = 7,
+    /// Denotes that the field in a resource (a message annotated with
+    /// google.api.resource) is used in the resource name to uniquely identify the
+    /// resource. For AIP-compliant APIs, this should only be applied to the
+    /// `name` field on the resource.
+    ///
+    /// This behavior should not be applied to references to other resources within
+    /// the message.
+    ///
+    /// The identifier field of resources often have different field behavior
+    /// depending on the request it is embedded in (e.g. for Create methods name
+    /// is optional and unused, while for Update methods it is required). Instead
+    /// of method-specific annotations, only `IDENTIFIER` is required.
+    Identifier = 8,
 }
 impl FieldBehavior {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -900,6 +913,7 @@ impl FieldBehavior {
             FieldBehavior::Immutable => "IMMUTABLE",
             FieldBehavior::UnorderedList => "UNORDERED_LIST",
             FieldBehavior::NonEmptyDefault => "NON_EMPTY_DEFAULT",
+            FieldBehavior::Identifier => "IDENTIFIER",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -913,6 +927,7 @@ impl FieldBehavior {
             "IMMUTABLE" => Some(Self::Immutable),
             "UNORDERED_LIST" => Some(Self::UnorderedList),
             "NON_EMPTY_DEFAULT" => Some(Self::NonEmptyDefault),
+            "IDENTIFIER" => Some(Self::Identifier),
             _ => None,
         }
     }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-582](https://mindvalley.atlassian.net/browse/PXP-582) and [PXP-583](https://mindvalley.atlassian.net/browse/PXP-583) 
## What's Changed

<!-- Explain what is changed in this pull request -->

### Added 
- [x] Add `DefaultErrorHandler` for default API channel
- [x] Add `CanaryErrorHandler` for canary API channel

### Changed
- [x] The error from `wukong_sdk` now mostly only error code (from `APIError::ApplicationNotFound { application: "" }` -> `APIError::ApplicationNotFound`)
- The reason why we remove the context in the error value is because we now doing centralized error handling, which we don't know what is the context value in advance (`application`, `name`, `pipeline` and etc.). 

<!-- ### Fixed -->


[PXP-583]: https://mindvalley.atlassian.net/browse/PXP-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PXP-582]: https://mindvalley.atlassian.net/browse/PXP-582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ