### PR TITLE
PXP-596: Optimize the logs rendering on tui

### DIFF
--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -19,7 +19,7 @@ pub enum AppReturn {
     Continue,
 }
 
-pub const MAX_LOG_ENTRIES_LENGTH: usize = 200;
+pub const MAX_LOG_ENTRIES_LENGTH: usize = 1_000;
 
 pub struct State {
     pub current_application: String,

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -35,7 +35,7 @@ pub struct State {
     pub builds: Vec<Build>,
     pub deployments: Vec<Deployment>,
     pub has_log_errors: bool,
-    pub log_entries: Box<Vec<LogEntry>>,
+    pub log_entries: Vec<LogEntry>,
     pub log_entries_length: usize,
     // pub log_entries_next_page_token: Option<String>,
     pub last_log_entry_timestamp: Option<String>,
@@ -105,7 +105,7 @@ impl App {
                 deployments: vec![],
                 last_log_entry_timestamp: None,
                 has_log_errors: false,
-                log_entries: Box::new(vec![]),
+                log_entries: vec![],
                 log_entries_length: 0,
 
                 logs_vertical_scroll_state: ScrollbarState::default(),

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -38,7 +38,7 @@ pub struct State {
     pub log_entries: Vec<LogEntry>,
     pub log_entries_length: usize,
     pub max_log_entries_length: usize,
-    // pub log_entries_next_page_token: Option<String>,
+
     pub last_log_entry_timestamp: Option<String>,
     // ui controls
     pub logs_vertical_scroll_state: ScrollbarState,

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -37,6 +37,7 @@ pub struct State {
     pub has_log_errors: bool,
     pub log_entries: Vec<LogEntry>,
     pub log_entries_length: usize,
+    pub max_log_entries_length: usize,
     // pub log_entries_next_page_token: Option<String>,
     pub last_log_entry_timestamp: Option<String>,
     // ui controls
@@ -105,8 +106,9 @@ impl App {
                 deployments: vec![],
                 last_log_entry_timestamp: None,
                 has_log_errors: false,
-                log_entries: vec![],
                 log_entries_length: 0,
+                log_entries: Vec::with_capacity(1_000),
+                max_log_entries_length: 1_000,
 
                 logs_vertical_scroll_state: ScrollbarState::default(),
                 logs_horizontal_scroll_state: ScrollbarState::default(),

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -19,6 +19,8 @@ pub enum AppReturn {
     Continue,
 }
 
+pub const MAX_LOG_ENTRIES_LENGTH: usize = 1_000;
+
 pub struct State {
     pub current_application: String,
     pub current_namespace: String,
@@ -37,7 +39,6 @@ pub struct State {
     pub has_log_errors: bool,
     pub log_entries: Vec<LogEntry>,
     pub log_entries_length: usize,
-    pub max_log_entries_length: usize,
 
     pub last_log_entry_timestamp: Option<String>,
     // ui controls
@@ -108,7 +109,6 @@ impl App {
                 has_log_errors: false,
                 log_entries_length: 0,
                 log_entries: Vec::with_capacity(1_000),
-                max_log_entries_length: 1_000,
 
                 logs_vertical_scroll_state: ScrollbarState::default(),
                 logs_horizontal_scroll_state: ScrollbarState::default(),

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -34,9 +34,9 @@ pub struct State {
     // fetch data
     pub builds: Vec<Build>,
     pub deployments: Vec<Deployment>,
-    pub log_entries_hash_map: HashMap<String, LogEntry>,
     pub has_log_errors: bool,
-    pub log_entries_ids: Vec<String>,
+    pub log_entries: Box<Vec<LogEntry>>,
+    pub log_entries_length: usize,
     // pub log_entries_next_page_token: Option<String>,
     pub last_log_entry_timestamp: Option<String>,
     // ui controls
@@ -104,9 +104,9 @@ impl App {
                 builds: vec![],
                 deployments: vec![],
                 last_log_entry_timestamp: None,
-                log_entries_hash_map: HashMap::new(),
-                log_entries_ids: vec![],
                 has_log_errors: false,
+                log_entries: Box::new(vec![]),
+                log_entries_length: 0,
 
                 logs_vertical_scroll_state: ScrollbarState::default(),
                 logs_horizontal_scroll_state: ScrollbarState::default(),

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Instant};
+use std::time::Instant;
 
 use ratatui::widgets::ScrollbarState;
 use tokio::sync::mpsc::Sender;

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -19,7 +19,7 @@ pub enum AppReturn {
     Continue,
 }
 
-pub const MAX_LOG_ENTRIES_LENGTH: usize = 1_000;
+pub const MAX_LOG_ENTRIES_LENGTH: usize = 200;
 
 pub struct State {
     pub current_application: String,

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -252,31 +252,19 @@ async fn update_logs_entries(app: Arc<Mutex<App>>, log_entries: Option<Vec<LogEn
                     .to_string(),
             );
 
-            entries.into_iter().for_each(|entry| {
-                if app_ref
-                    .state
-                    .log_entries_hash_map
-                    .get(&entry.insert_id)
-                    .is_none()
-                {
-                    app_ref.state.log_entries_ids.push(entry.insert_id.clone());
-                    app_ref
-                        .state
-                        .log_entries_hash_map
-                        .insert(entry.insert_id.clone(), entry);
-                }
-            });
+            app_ref.state.log_entries.extend(entries);
+            app_ref.state.log_entries_length = app_ref.state.log_entries.len();
 
             // Currently ratatui don't provide scroll to bottom function,
             // so we need to set the scroll to the bottom manually by this hack
             // waiting this https://github.com/fdehau/tui-rs/issues/89
             if app_ref.state.logs_enable_auto_scroll_to_bottom {
-                app_ref.state.logs_vertical_scroll = app_ref.state.log_entries_ids.len()
+                app_ref.state.logs_vertical_scroll = app_ref.state.log_entries_length
                     - (app_ref.state.logs_widget_height - 4) as usize;
                 app_ref.state.logs_vertical_scroll_state = app_ref
                     .state
                     .logs_vertical_scroll_state
-                    .position(app_ref.state.log_entries_ids.len());
+                    .position(app_ref.state.log_entries_length);
             }
         }
     }

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -256,7 +256,7 @@ async fn update_logs_entries(app: Arc<Mutex<App>>, log_entries: Option<Vec<LogEn
             if app_ref.state.log_entries_length + entries.len() > MAX_LOG_ENTRIES_LENGTH {
                 let excess =
                     (app_ref.state.log_entries_length + entries.len()) - MAX_LOG_ENTRIES_LENGTH;
-          
+
                 if excess > 0 {
                     app_ref.state.log_entries.drain(..excess);
                 }

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -253,9 +253,10 @@ async fn update_logs_entries(app: Arc<Mutex<App>>, log_entries: Option<Vec<LogEn
             );
 
             // Keep the log entries length to the max_log_entries_length:
-            if app_ref.state.log_entries.len() + entries.len() > MAX_LOG_ENTRIES_LENGTH {
+            if app_ref.state.log_entries_length + entries.len() > MAX_LOG_ENTRIES_LENGTH {
                 let excess =
-                    (app_ref.state.log_entries.len() + entries.len()) - MAX_LOG_ENTRIES_LENGTH;
+                    (app_ref.state.log_entries_length + entries.len()) - MAX_LOG_ENTRIES_LENGTH;
+          
                 if excess > 0 {
                     app_ref.state.log_entries.drain(..excess);
                 }

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -8,7 +8,7 @@ use crate::{
     commands::{
         application::generate_filter,
         tui::{
-            app::{App, Build, Commit, Deployment},
+            app::{App, Build, Commit, Deployment, MAX_LOG_ENTRIES_LENGTH},
             StatefulList,
         },
     },
@@ -253,11 +253,9 @@ async fn update_logs_entries(app: Arc<Mutex<App>>, log_entries: Option<Vec<LogEn
             );
 
             // Keep the log entries length to the max_log_entries_length:
-            if app_ref.state.log_entries.len() + entries.len()
-                > app_ref.state.max_log_entries_length
-            {
-                let excess = (app_ref.state.log_entries.len() + entries.len())
-                    - app_ref.state.max_log_entries_length;
+            if app_ref.state.log_entries.len() + entries.len() > MAX_LOG_ENTRIES_LENGTH {
+                let excess =
+                    (app_ref.state.log_entries.len() + entries.len()) - MAX_LOG_ENTRIES_LENGTH;
                 if excess > 0 {
                     app_ref.state.log_entries.drain(..excess);
                 }

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -252,6 +252,17 @@ async fn update_logs_entries(app: Arc<Mutex<App>>, log_entries: Option<Vec<LogEn
                     .to_string(),
             );
 
+            // Keep the log entries length to the max_log_entries_length:
+            if app_ref.state.log_entries.len() + entries.len()
+                > app_ref.state.max_log_entries_length
+            {
+                let excess = (app_ref.state.log_entries.len() + entries.len())
+                    - app_ref.state.max_log_entries_length;
+                if excess > 0 {
+                    app_ref.state.log_entries.drain(..excess);
+                }
+            }
+
             app_ref.state.log_entries.extend(entries);
             app_ref.state.log_entries_length = app_ref.state.log_entries.len();
 

--- a/cli/src/commands/tui/mod.rs
+++ b/cli/src/commands/tui/mod.rs
@@ -134,7 +134,7 @@ pub async fn start_ui(app: &Arc<Mutex<App>>) -> std::io::Result<bool> {
         terminal.draw(|frame| ui::draw(frame, &mut app_ref))?;
 
         // move cursor to the top left corner to avoid screen scrolling:
-        terminal.set_cursor(1 + 0, 1)?;
+        terminal.set_cursor(1, 1)?;
 
         let result = match event_manager.next().unwrap() {
             events::Event::Input(key) => app_ref.handle_input(key).await,

--- a/cli/src/commands/tui/mod.rs
+++ b/cli/src/commands/tui/mod.rs
@@ -133,6 +133,7 @@ pub async fn start_ui(app: &Arc<Mutex<App>>) -> std::io::Result<bool> {
 
         terminal.draw(|frame| ui::draw(frame, &mut app_ref))?;
 
+        // move cursor to the top left corner to avoid screen scrolling:
         terminal.set_cursor(1 + 0, 1)?;
 
         let result = match event_manager.next().unwrap() {
@@ -144,8 +145,6 @@ pub async fn start_ui(app: &Arc<Mutex<App>>) -> std::io::Result<bool> {
             break;
         }
 
-        // Delay UI request until first render, will have the effect of improving
-        // startup speed
         if is_first_render {
             // fetch data on the first frame
             app_ref.dispatch(NetworkEvent::FetchDeployments).await;

--- a/cli/src/commands/tui/mod.rs
+++ b/cli/src/commands/tui/mod.rs
@@ -133,7 +133,7 @@ pub async fn start_ui(app: &Arc<Mutex<App>>) -> std::io::Result<bool> {
 
         terminal.draw(|frame| ui::draw(frame, &mut app_ref))?;
 
-        // terminal.set_cursor(1 + 0, 1)?;
+        terminal.set_cursor(1 + 0, 1)?;
 
         let result = match event_manager.next().unwrap() {
             events::Event::Input(key) => app_ref.handle_input(key).await,

--- a/cli/src/commands/tui/mod.rs
+++ b/cli/src/commands/tui/mod.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{io::stdout, sync::Arc, time::Duration};
 
 use crate::{
     config::{ApiChannel, Config},
@@ -112,31 +112,28 @@ pub async fn handle_tui(channel: ApiChannel) -> Result<bool, WKCliError> {
 }
 
 pub async fn start_ui(app: &Arc<Mutex<App>>) -> std::io::Result<bool> {
-    let mut stdout = std::io::stdout();
-    enable_raw_mode()?;
+    let mut stdout = stdout();
     execute!(stdout, EnterAlternateScreen).expect("unable to enter alternate screen");
+    enable_raw_mode()?;
 
-    let mut terminal = Terminal::new(CrosstermBackend::new(stdout))?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    terminal.hide_cursor()?;
 
     // The lower the tick_rate, the higher the FPS, but also the higher the CPU usage.
-    let tick_rate = Duration::from_millis(200);
+    let tick_rate = Duration::from_millis(1000);
     let event_manager = EventManager::new();
     event_manager.spawn_event_listen_thread(tick_rate);
 
-    let mut the_first_frame = true;
+    let mut is_first_render = true;
 
     loop {
         let mut app_ref = app.lock().await;
 
-        if the_first_frame {
-            // fetch data on the first frame
-            app_ref.dispatch(NetworkEvent::FetchDeployments).await;
-            app_ref.dispatch(NetworkEvent::FetchBuilds).await;
-
-            the_first_frame = false;
-        }
-
         terminal.draw(|frame| ui::draw(frame, &mut app_ref))?;
+
+        // terminal.set_cursor(1 + 0, 1)?;
 
         let result = match event_manager.next().unwrap() {
             events::Event::Input(key) => app_ref.handle_input(key).await,
@@ -146,7 +143,19 @@ pub async fn start_ui(app: &Arc<Mutex<App>>) -> std::io::Result<bool> {
         if result == AppReturn::Exit {
             break;
         }
+
+        // Delay UI request until first render, will have the effect of improving
+        // startup speed
+        if is_first_render {
+            // fetch data on the first frame
+            app_ref.dispatch(NetworkEvent::FetchDeployments).await;
+            app_ref.dispatch(NetworkEvent::FetchBuilds).await;
+
+            is_first_render = false;
+        }
     }
+
+    terminal.show_cursor()?;
 
     // post-run
     disable_raw_mode()?;
@@ -158,7 +167,6 @@ pub async fn start_ui(app: &Arc<Mutex<App>>) -> std::io::Result<bool> {
     .expect("unable to leave alternate screen");
 
     terminal.clear()?;
-    terminal.show_cursor()?;
 
     Ok(true)
 }

--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -36,7 +36,11 @@ impl LogsWidget {
         let title = Block::default()
             .title(format!(
                 "Use arrow keys or h j k l to scroll ◄ ▲ ▼ ►. Total {} logs.",
-                app.state.log_entries_length
+                if app.state.log_entries_length == app.state.max_log_entries_length {
+                    format!("{}+", app.state.log_entries_length)
+                } else {
+                    app.state.log_entries_length.to_string()
+                }
             ))
             .title_alignment(Alignment::Center)
             .style(Style::default().fg(Color::DarkGray));

--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -6,7 +6,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::commands::tui::app::App;
+use crate::commands::tui::app::{App, MAX_LOG_ENTRIES_LENGTH};
 
 pub struct LogsWidget;
 
@@ -36,7 +36,7 @@ impl LogsWidget {
         let title = Block::default()
             .title(format!(
                 "Use arrow keys or h j k l to scroll ◄ ▲ ▼ ►. Total {} logs.",
-                if app.state.log_entries_length == app.state.max_log_entries_length {
+                if app.state.log_entries_length == MAX_LOG_ENTRIES_LENGTH {
                     format!("{}+", app.state.log_entries_length)
                 } else {
                     app.state.log_entries_length.to_string()

--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -36,7 +36,7 @@ impl LogsWidget {
         let title = Block::default()
             .title(format!(
                 "Use arrow keys or h j k l to scroll ◄ ▲ ▼ ►. Total {} logs.",
-                app.state.log_entries_ids.len()
+                app.state.log_entries_length
             ))
             .title_alignment(Alignment::Center)
             .style(Style::default().fg(Color::DarkGray));
@@ -63,30 +63,30 @@ impl LogsWidget {
             return;
         }
 
-        let mut log_entries = vec![];
-        let mut first_color = true;
-        for id in &app.state.log_entries_ids {
-            if let Some(log) = app.state.log_entries_hash_map.get(id) {
-                if first_color {
-                    log_entries.push(Line::styled(
-                        format!("{}", log),
-                        Style::default().fg(Color::White),
-                    ));
-                } else {
-                    log_entries.push(Line::styled(
-                        format!("{}", log),
-                        Style::default().fg(Color::LightCyan),
-                    ));
-                }
+        let mut first_color = false;
 
+        let log_entries = app
+            .state
+            .log_entries
+            .iter()
+            .map(|log_entry| {
                 first_color = !first_color;
-            }
-        }
+
+                if first_color {
+                    Line::styled(format!("{}", log_entry), Style::default().fg(Color::White))
+                } else {
+                    Line::styled(
+                        format!("{}", log_entry),
+                        Style::default().fg(Color::LightCyan),
+                    )
+                }
+            })
+            .collect::<Vec<Line>>();
 
         app.state.logs_vertical_scroll_state = app
             .state
             .logs_vertical_scroll_state
-            .content_length(log_entries.len());
+            .content_length(app.state.log_entries_length);
 
         let paragraph = Paragraph::new(log_entries)
             .block(Block::default().padding(Padding::new(1, 1, 0, 0)))


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary
Update the various logics on logs to make sure that wukong TUI to improve the performance on lower end devices
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: https://mindvalley.atlassian.net/browse/PXP-596

## What's Changed

<!-- Explain what is changed in this pull request -->

- [x] Change the logic of storing the logs to make it less heavy during re-rendering
- [x] Limit the log history to 1_000
- [x] Reduce the tick rate
- [x] Set cursor to fixed place for now to avoid screen scrolling on new printLn

<!-- ### Added -->

<!-- ### Changed -->

<!-- ### Fixed -->
