### PR TITLE
PXP-598: Add log tailing hotkey

### DIFF
--- a/cli/src/commands/tui/action.rs
+++ b/cli/src/commands/tui/action.rs
@@ -47,7 +47,7 @@ impl Display for Action {
             Action::OpenNamespaceSelection => write!(f, "Select namespace"),
             Action::OpenVersionSelection => write!(f, "Select version"),
             Action::ToggleLogsTailing => write!(f, "Toggle logs tailing"),
-            Action::ShowErrorAndAbove => write!(f, "Show error logs and above"),
+            Action::ShowErrorAndAbove => write!(f, "Show errors logs only"),
             Action::Quit => write!(f, "Quit"),
         }
     }

--- a/cli/src/commands/tui/action.rs
+++ b/cli/src/commands/tui/action.rs
@@ -6,6 +6,7 @@ use super::events::key::Key;
 pub enum Action {
     OpenNamespaceSelection,
     OpenVersionSelection,
+    ToggleLogsTailing,
     Quit,
 }
 
@@ -24,6 +25,7 @@ impl Action {
         match self {
             Action::OpenNamespaceSelection => &[Key::Char('n')],
             Action::OpenVersionSelection => &[Key::Char('v')],
+            Action::ToggleLogsTailing => &[Key::Char('t')],
             Action::Quit => &[Key::Char('q')],
         }
     }
@@ -40,6 +42,7 @@ impl Display for Action {
         match self {
             Action::OpenNamespaceSelection => write!(f, "Select namespace"),
             Action::OpenVersionSelection => write!(f, "Select version"),
+            Action::ToggleLogsTailing => write!(f, "Toggle logs tailing"),
             Action::Quit => write!(f, "Quit"),
         }
     }

--- a/cli/src/commands/tui/action.rs
+++ b/cli/src/commands/tui/action.rs
@@ -14,9 +14,11 @@ pub enum Action {
 impl Action {
     // iterator for enum https://stackoverflow.com/a/21376984
     pub fn iterator() -> Iter<'static, Action> {
-        static ACTIONS: [Action; 3] = [
+        static ACTIONS: [Action; 5] = [
             Action::OpenNamespaceSelection,
             Action::OpenVersionSelection,
+            Action::ToggleLogsTailing,
+            Action::ShowErrorLogsOnly,
             Action::Quit,
         ];
         ACTIONS.iter()

--- a/cli/src/commands/tui/action.rs
+++ b/cli/src/commands/tui/action.rs
@@ -6,7 +6,7 @@ use super::events::key::Key;
 pub enum Action {
     OpenNamespaceSelection,
     OpenVersionSelection,
-    ShowErrorLogsOnly,
+    ShowErrorAndAbove,
     ToggleLogsTailing,
     Quit,
 }
@@ -18,7 +18,7 @@ impl Action {
             Action::OpenNamespaceSelection,
             Action::OpenVersionSelection,
             Action::ToggleLogsTailing,
-            Action::ShowErrorLogsOnly,
+            Action::ShowErrorAndAbove,
             Action::Quit,
         ];
         ACTIONS.iter()
@@ -29,7 +29,7 @@ impl Action {
             Action::OpenNamespaceSelection => &[Key::Char('n')],
             Action::OpenVersionSelection => &[Key::Char('v')],
             Action::ToggleLogsTailing => &[Key::Ctrl('t')],
-            Action::ShowErrorLogsOnly => &[Key::Ctrl('e')],
+            Action::ShowErrorAndAbove => &[Key::Ctrl('e')],
             Action::Quit => &[Key::Char('q')],
         }
     }
@@ -47,7 +47,7 @@ impl Display for Action {
             Action::OpenNamespaceSelection => write!(f, "Select namespace"),
             Action::OpenVersionSelection => write!(f, "Select version"),
             Action::ToggleLogsTailing => write!(f, "Toggle logs tailing"),
-            Action::ShowErrorLogsOnly => write!(f, "Show error logs only"),
+            Action::ShowErrorAndAbove => write!(f, "Show error logs only"),
             Action::Quit => write!(f, "Quit"),
         }
     }

--- a/cli/src/commands/tui/action.rs
+++ b/cli/src/commands/tui/action.rs
@@ -47,7 +47,7 @@ impl Display for Action {
             Action::OpenNamespaceSelection => write!(f, "Select namespace"),
             Action::OpenVersionSelection => write!(f, "Select version"),
             Action::ToggleLogsTailing => write!(f, "Toggle logs tailing"),
-            Action::ShowErrorAndAbove => write!(f, "Show error logs only"),
+            Action::ShowErrorAndAbove => write!(f, "Show error logs and above"),
             Action::Quit => write!(f, "Quit"),
         }
     }

--- a/cli/src/commands/tui/action.rs
+++ b/cli/src/commands/tui/action.rs
@@ -25,7 +25,7 @@ impl Action {
         match self {
             Action::OpenNamespaceSelection => &[Key::Char('n')],
             Action::OpenVersionSelection => &[Key::Char('v')],
-            Action::ToggleLogsTailing => &[Key::Char('t')],
+            Action::ToggleLogsTailing => &[Key::Ctrl('t')],
             Action::Quit => &[Key::Char('q')],
         }
     }

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -142,7 +142,7 @@ impl App {
                 Action::OpenNamespaceSelection,
                 Action::OpenVersionSelection,
                 Action::ToggleLogsTailing,
-                Action::ShowErrorLogsOnly,
+                Action::ShowErrorAndAbove,
                 Action::Quit,
             ],
             network_event_sender: sender,
@@ -204,7 +204,7 @@ impl App {
                 self.state.logs_tailing = !self.state.logs_tailing;
                 AppReturn::Continue
             }
-            Some(Action::ShowErrorLogsOnly) => {
+            Some(Action::ShowErrorAndAbove) => {
                 self.dispatch(NetworkEvent::GetGCloudLogs).await;
 
                 self.state.is_fetching_log_entries = true;

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -171,7 +171,7 @@ impl App {
             self.state.instant_since_last_log_entries_poll = Instant::now();
 
             if self.state.logs_tailing {
-                self.dispatch(NetworkEvent::FetchGCloudLogs).await;
+                self.dispatch(NetworkEvent::GetGCloudLogs).await;
             }
         }
 

--- a/cli/src/commands/tui/ui/help.rs
+++ b/cli/src/commands/tui/ui/help.rs
@@ -30,7 +30,7 @@ impl HelpWidget {
 
         let widget = Table::new(rows)
             .block(Block::default().borders(Borders::TOP | Borders::BOTTOM | Borders::RIGHT))
-            .widths(&[Constraint::Length(4), Constraint::Min(20)])
+            .widths(&[Constraint::Length(8), Constraint::Min(20)])
             .column_spacing(1);
 
         frame.render_widget(widget, rect);

--- a/cli/src/commands/tui/ui/help.rs
+++ b/cli/src/commands/tui/ui/help.rs
@@ -30,7 +30,7 @@ impl HelpWidget {
 
         let widget = Table::new(rows)
             .block(Block::default().borders(Borders::TOP | Borders::BOTTOM | Borders::RIGHT))
-            .widths(&[Constraint::Length(8), Constraint::Min(20)])
+            .widths(&[Constraint::Length(8), Constraint::Min(21)])
             .column_spacing(1);
 
         frame.render_widget(widget, rect);

--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -61,16 +61,16 @@ fn create_main_block() -> Block<'static> {
 fn create_title(state: &State) -> Block {
     Block::default()
         .title(format!(
-          "Use arrow keys or h j k l to scroll ◄ ▲ ▼ ►. Total {} logs. \t [Severity: {}], [Tailing: {}]",
+          "Use arrow keys or h j k l to scroll ◄ ▲ ▼ ►. Total {} logs. \t [Severity{}], [Tailing: {}]",
           if state.log_entries_length == MAX_LOG_ENTRIES_LENGTH {
               format!("{}+", state.log_entries_length)
           } else {
               state.log_entries_length.to_string()
           },
           if state.logs_severity == Some(LogSeverity::Error) {
-              "Error".to_string()
+              " >= Error".to_string()
           } else {
-              "Default".to_string()
+              ": Default".to_string()
           },
           if state.logs_tailing {
             "On"


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

Introduce a new hot key, Ctrl+t (t stand for tailing), to allow pause / resume the logs tailing. 

When triggered, it will either pause the logs tailing operation, or resuming to tail the logs in the Logs panel.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: https://mindvalley.atlassian.net/browse/PXP-598

## What's Changed

- [x] Add new hotkey `Ctrl+t`
- [x] Code cleanup for logs UI to make it more readable 

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

<!-- ### Fixed -->
