### PR TITLE
PXP-611: add error logs filter on tui

### DIFF
--- a/cli/src/commands/application/logs.rs
+++ b/cli/src/commands/application/logs.rs
@@ -255,7 +255,7 @@ pub fn generate_filter(
             filter.push_str(" AND ");
         }
 
-        filter.push_str(&format!("severity={:?}", severity.as_str_name()));
+        filter.push_str(&format!("severity>={:?}", severity.as_str_name()));
     }
 
     filter.push_str(" AND ");

--- a/cli/src/commands/tui/action.rs
+++ b/cli/src/commands/tui/action.rs
@@ -6,6 +6,7 @@ use super::events::key::Key;
 pub enum Action {
     OpenNamespaceSelection,
     OpenVersionSelection,
+    ShowErrorLogsOnly,
     Quit,
 }
 
@@ -24,6 +25,7 @@ impl Action {
         match self {
             Action::OpenNamespaceSelection => &[Key::Char('n')],
             Action::OpenVersionSelection => &[Key::Char('v')],
+            Action::ShowErrorLogsOnly => &[Key::Ctrl('e')],
             Action::Quit => &[Key::Char('q')],
         }
     }
@@ -40,6 +42,7 @@ impl Display for Action {
         match self {
             Action::OpenNamespaceSelection => write!(f, "Select namespace"),
             Action::OpenVersionSelection => write!(f, "Select version"),
+            Action::ShowErrorLogsOnly => write!(f, "Show error logs only"),
             Action::Quit => write!(f, "Quit"),
         }
     }

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -247,9 +247,13 @@ impl App {
                 }
                 Key::Ctrl('e') => {
                     self.dispatch(NetworkEvent::GetGCloudLogs).await;
+
                     self.state.is_fetching_log_entries = true;
                     self.state.start_polling_log_entries = false;
-                    self.state.has_log_errors = false;
+
+                    self.state.log_entries = vec![];
+                    self.state.log_entries_length = 0;
+                    // Need to reset scroll, or else it will be out of bound
 
                     // Add if not already in the list
                     // or else remove it

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -58,7 +58,7 @@ pub struct State {
     // ui state
     pub logs_widget_height: u16,
     pub logs_widget_width: u16,
-    pub logs_serverity: LogSeverity,
+    pub logs_serverity: Option<LogSeverity>,
 }
 
 pub struct App {
@@ -131,7 +131,7 @@ impl App {
 
                 logs_widget_width: 0,
                 logs_widget_height: 0,
-                logs_serverity: LogSeverity::default(),
+                logs_serverity: None,
             },
             namespace_selections,
             version_selections,
@@ -254,8 +254,8 @@ impl App {
                     // Add if not already in the list
                     // or else remove it
                     self.state.logs_serverity = match self.state.logs_serverity {
-                        LogSeverity::Error => LogSeverity::default(),
-                        _ => LogSeverity::Error,
+                        Some(LogSeverity::Error) => None,
+                        _ => Some(LogSeverity::Error),
                     };
 
                     AppReturn::Continue

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -1,10 +1,7 @@
 use std::sync::Arc;
 
 use tokio::sync::{Mutex, MutexGuard};
-use wukong_sdk::services::gcloud::{
-    google::logging::{r#type::LogSeverity, v2::LogEntry},
-    LogEntries, LogEntriesOptions,
-};
+use wukong_sdk::services::gcloud::{google::logging::v2::LogEntry, LogEntries, LogEntriesOptions};
 
 use crate::{
     auth,
@@ -296,11 +293,7 @@ async fn get_gcloud_logs(app: Arc<Mutex<App>>, wk_client: &mut WKClient) -> Resu
                         &cluster.k8s_namespace,
                         &since,
                         &None,
-                        if logs_serverity == LogSeverity::Error {
-                            &true
-                        } else {
-                            &false
-                        },
+                        &logs_serverity,
                     )?;
                     let resource_names = vec![format!("projects/{}", cluster.google_project_id)];
 

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -151,8 +151,15 @@ async fn update_logs_entries(app: Arc<Mutex<App>>, log_entries: Option<Vec<LogEn
             // so we need to set the scroll to the bottom manually by this hack
             // waiting this https://github.com/fdehau/tui-rs/issues/89
             if app_ref.state.logs_enable_auto_scroll_to_bottom {
-                app_ref.state.logs_vertical_scroll = app_ref.state.log_entries_length
-                    - (app_ref.state.logs_widget_height - 4) as usize;
+                let widget_height = app_ref.state.logs_widget_height - 4;
+
+                app_ref.state.logs_vertical_scroll =
+                    if app_ref.state.log_entries_length > widget_height as usize {
+                        app_ref.state.log_entries_length - widget_height as usize
+                    } else {
+                        0
+                    };
+
                 app_ref.state.logs_vertical_scroll_state = app_ref
                     .state
                     .logs_vertical_scroll_state

--- a/cli/src/commands/tui/ui/help.rs
+++ b/cli/src/commands/tui/ui/help.rs
@@ -30,7 +30,7 @@ impl HelpWidget {
 
         let widget = Table::new(rows)
             .block(Block::default().borders(Borders::TOP | Borders::BOTTOM | Borders::RIGHT))
-            .widths(&[Constraint::Length(4), Constraint::Min(20)])
+            .widths(&[Constraint::Length(8), Constraint::Min(20)])
             .column_spacing(1);
 
         frame.render_widget(widget, rect);

--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -35,12 +35,13 @@ impl LogsWidget {
 
         let title = Block::default()
             .title(format!(
-                "Use arrow keys or h j k l to scroll ◄ ▲ ▼ ►. Total {} logs.",
+                "Use arrow keys or h j k l to scroll ◄ ▲ ▼ ►. Total {} logs. \t {}",
                 if app.state.log_entries_length == MAX_LOG_ENTRIES_LENGTH {
                     format!("{}+", app.state.log_entries_length)
                 } else {
                     app.state.log_entries_length.to_string()
-                }
+                },
+                format!("[Severity: {}]", app.state.logs_serverity.as_str_name())
             ))
             .title_alignment(Alignment::Center)
             .style(Style::default().fg(Color::DarkGray));

--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -5,6 +5,7 @@ use ratatui::{
     widgets::{Block, Borders, Padding, Paragraph, Scrollbar, ScrollbarOrientation},
     Frame,
 };
+use wukong_sdk::services::gcloud::google::logging::r#type::LogSeverity;
 
 use crate::commands::tui::app::{App, MAX_LOG_ENTRIES_LENGTH};
 
@@ -41,7 +42,14 @@ impl LogsWidget {
                 } else {
                     app.state.log_entries_length.to_string()
                 },
-                format!("[Severity: {}]", app.state.logs_serverity.as_str_name())
+                format!(
+                    "[Severity: {}]",
+                    if app.state.logs_serverity == Some(LogSeverity::Error) {
+                        "Error"
+                    } else {
+                        "Default"
+                    }
+                )
             ))
             .title_alignment(Alignment::Center)
             .style(Style::default().fg(Color::DarkGray));

--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -36,20 +36,17 @@ impl LogsWidget {
 
         let title = Block::default()
             .title(format!(
-                "Use arrow keys or h j k l to scroll ◄ ▲ ▼ ►. Total {} logs. \t {}",
+                "Use arrow keys or h j k l to scroll ◄ ▲ ▼ ►. Total {} logs. \t [Severity: {}]",
                 if app.state.log_entries_length == MAX_LOG_ENTRIES_LENGTH {
                     format!("{}+", app.state.log_entries_length)
                 } else {
                     app.state.log_entries_length.to_string()
                 },
-                format!(
-                    "[Severity: {}]",
-                    if app.state.logs_serverity == Some(LogSeverity::Error) {
-                        "Error"
-                    } else {
-                        "Default"
-                    }
-                )
+                if app.state.logs_serverity == Some(LogSeverity::Error) {
+                    "Error".to_string()
+                } else {
+                    "Default".to_string()
+                }
             ))
             .title_alignment(Alignment::Center)
             .style(Style::default().fg(Color::DarkGray));


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

Introduce a new hotkey, `Ctrl+e`, to allow showing the errors only. This is equivalent to passing the --errors parameter into the application logs command.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: https://mindvalley.atlassian.net/browse/PXP-611

## What's Changed

<!-- Explain what is changed in this pull request -->

- [x] Modify `generate_filter` func to accept severity levels directly
- [x] Add new hotkey `Ctrl+e` to toggle between error and all severity 
- [x] Fix a bug that goes to panic if logs length is smaller than the logs height

<!-- ### Added -->

<!-- ### Changed -->

<!-- ### Fixed -->
