### PR TITLE
PXP-616: [CLI] Log Entries is not reset after a new namespace or a new version is selected

### DIFF
--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -346,6 +346,7 @@ async fn get_gcloud_logs(app: Arc<Mutex<App>>, wk_client: &mut WKClient) -> Resu
                     let mut next_page_token = log.next_page_token.clone();
                     update_logs_entries(Arc::clone(&app), log.entries).await;
 
+                    // repeat fetching logs until there is no next_page_token
                     let app = Arc::clone(&app);
                     while next_page_token.is_some() && next_page_token != Some("".to_string()) {
                         log = fetch_log_entries(

--- a/cli/src/commands/tui/ui/namespace_selection.rs
+++ b/cli/src/commands/tui/ui/namespace_selection.rs
@@ -86,10 +86,7 @@ impl NamespaceSelectionWidget {
 async fn fetch_and_reset_polling(app: &mut App, selected_version: String) {
     app.state.current_namespace = Some(selected_version);
     app.state.log_entries = vec![];
-    app.state.log_entries_length = 0;
-
-    app.dispatch(NetworkEvent::GetBuilds).await;
-    app.dispatch(NetworkEvent::GetGCloudLogs).await;
+    app.state.log_entries_length = app.state.log_entries.len();
 
     app.state.is_fetching_log_entries = true;
     app.state.start_polling_log_entries = false;
@@ -97,6 +94,8 @@ async fn fetch_and_reset_polling(app: &mut App, selected_version: String) {
     // reset error state
     app.state.log_entries_error = None;
     app.state.has_log_errors = false;
+
+    app.dispatch(NetworkEvent::GetBuilds).await;
 }
 
 fn set_current_screen_to_main(app: &mut App) {

--- a/cli/src/commands/tui/ui/namespace_selection.rs
+++ b/cli/src/commands/tui/ui/namespace_selection.rs
@@ -69,6 +69,8 @@ impl NamespaceSelectionWidget {
                     .unwrap();
 
                 if let Some(current_namespace) = &app.state.current_namespace {
+                    // if different namespace is selected, fetch the new builds and gcloud logs
+                    // based on the new namespace
                     if current_namespace != selected {
                         fetch_and_reset_polling(app, selected.to_string()).await;
                     }
@@ -83,6 +85,9 @@ impl NamespaceSelectionWidget {
 
 async fn fetch_and_reset_polling(app: &mut App, selected_version: String) {
     app.state.current_namespace = Some(selected_version);
+    app.state.log_entries = vec![];
+    app.state.log_entries_length = 0;
+
     app.dispatch(NetworkEvent::GetBuilds).await;
     app.dispatch(NetworkEvent::GetGCloudLogs).await;
 

--- a/cli/src/commands/tui/ui/version_selection.rs
+++ b/cli/src/commands/tui/ui/version_selection.rs
@@ -87,9 +87,14 @@ async fn handle_enter_key(app: &mut App) {
 
 async fn fetch_and_reset_polling(app: &mut App, selected_version: String) {
     app.state.current_version = Some(selected_version);
+    app.state.log_entries = vec![];
+    app.state.log_entries_length = app.state.log_entries.len();
 
     app.state.is_fetching_log_entries = true;
     app.state.start_polling_log_entries = false;
+
+    // reset error state
+    app.state.log_entries_error = None;
     app.state.has_log_errors = false;
 
     app.dispatch(NetworkEvent::GetBuilds).await;


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary
There are few bugs found during my discoveries, so I made a PR to fix them together.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-616](https://mindvalley.atlassian.net/browse/PXP-616)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

### Fixed
- [x] Fix the `log entries` and `log_entries_length` is not reset after new namespace or new version is selected
- [x] Fix the duplicated gcloud API call after a new namespace is selected
- [x] Fix the gcloud API not being called after a new namespace or a new version is selected when the tailing is disabled


[PXP-616]: https://mindvalley.atlassian.net/browse/PXP-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ