### PR TITLE
PXP-627: [CLI] Key binding is incorrect for the logs panel

### DIFF
--- a/cli/src/commands/tui/handlers/log_filter_exclude.rs
+++ b/cli/src/commands/tui/handlers/log_filter_exclude.rs
@@ -7,15 +7,16 @@ use crate::commands::tui::{
 pub async fn handler(key: Key, app: &mut App) -> AppReturn {
     match key {
         key if common_key_events::back_event(key) => {
+            app.state.show_filter_bar = false;
             app.set_current_route_state(
                 Some(ActiveBlock::Log),
                 Some(ActiveBlock::Dialog(DialogContext::LogIncludeFilter)),
             );
         }
         key if common_key_events::delete_event(key) => delete_char(app),
-        key if Key::Right == key => move_cursor_right(&mut app.state.filter_bar_exclude_input),
-        key if Key::Left == key => move_cursor_left(app),
-        key if Key::Tab == key => move_to_next_input(app),
+        Key::Right => move_cursor_right(&mut app.state.filter_bar_exclude_input),
+        Key::Left => move_cursor_left(app),
+        Key::Tab=> move_to_next_input(app),
         Key::Char(new_char) => {
             enter_char(&mut app.state.filter_bar_exclude_input, new_char);
         }

--- a/cli/src/commands/tui/handlers/log_filter_exclude.rs
+++ b/cli/src/commands/tui/handlers/log_filter_exclude.rs
@@ -16,7 +16,7 @@ pub async fn handler(key: Key, app: &mut App) -> AppReturn {
         key if common_key_events::delete_event(key) => delete_char(app),
         Key::Right => move_cursor_right(&mut app.state.filter_bar_exclude_input),
         Key::Left => move_cursor_left(app),
-        Key::Tab=> move_to_next_input(app),
+        Key::Tab => move_to_next_input(app),
         Key::Char(new_char) => {
             enter_char(&mut app.state.filter_bar_exclude_input, new_char);
         }

--- a/cli/src/commands/tui/handlers/log_filter_include.rs
+++ b/cli/src/commands/tui/handlers/log_filter_include.rs
@@ -7,6 +7,7 @@ use crate::commands::tui::{
 pub async fn handler(key: Key, app: &mut App) -> AppReturn {
     match key {
         key if common_key_events::back_event(key) => {
+            app.state.show_filter_bar = false;
             app.set_current_route_state(
                 Some(ActiveBlock::Log),
                 Some(ActiveBlock::Dialog(DialogContext::LogIncludeFilter)),
@@ -15,9 +16,9 @@ pub async fn handler(key: Key, app: &mut App) -> AppReturn {
         key if common_key_events::delete_event(key) => {
             delete_char(&mut app.state.filter_bar_include_input)
         }
-        key if Key::Right == key => move_cursor_right(app),
-        key if Key::Left == key => move_cursor_left(&mut app.state.filter_bar_include_input),
-        key if Key::Tab == key => move_to_next_input(app),
+        Key::Right => move_cursor_right(app),
+        Key::Left => move_cursor_left(&mut app.state.filter_bar_include_input),
+        Key::Tab => move_to_next_input(app),
         Key::Char(new_char) => {
             enter_char(app, new_char);
         }

--- a/cli/src/commands/tui/handlers/log_search.rs
+++ b/cli/src/commands/tui/handlers/log_search.rs
@@ -7,14 +7,15 @@ use crate::commands::tui::{
 pub async fn handler(key: Key, app: &mut App) -> AppReturn {
     match key {
         key if common_key_events::back_event(key) => {
+            app.state.show_search_bar = false;
             app.set_current_route_state(
                 Some(ActiveBlock::Log),
                 Some(ActiveBlock::Dialog(DialogContext::LogIncludeFilter)),
             );
         }
         key if common_key_events::delete_event(key) => delete_char(&mut app.state.search_bar_input),
-        key if Key::Right == key => move_cursor_right(&mut app.state.search_bar_input),
-        key if Key::Left == key => move_cursor_left(&mut app.state.search_bar_input),
+        Key::Right => move_cursor_right(&mut app.state.search_bar_input),
+        Key::Left => move_cursor_left(&mut app.state.search_bar_input),
         Key::Char(new_char) => {
             enter_char(&mut app.state.search_bar_input, new_char);
         }

--- a/sdk/src/services/gcloud/api/google.api.rs
+++ b/sdk/src/services/gcloud/api/google.api.rs
@@ -884,6 +884,19 @@ pub enum FieldBehavior {
     /// a non-empty value will be returned. The user will not be aware of what
     /// non-empty value to expect.
     NonEmptyDefault = 7,
+    /// Denotes that the field in a resource (a message annotated with
+    /// google.api.resource) is used in the resource name to uniquely identify the
+    /// resource. For AIP-compliant APIs, this should only be applied to the
+    /// `name` field on the resource.
+    ///
+    /// This behavior should not be applied to references to other resources within
+    /// the message.
+    ///
+    /// The identifier field of resources often have different field behavior
+    /// depending on the request it is embedded in (e.g. for Create methods name
+    /// is optional and unused, while for Update methods it is required). Instead
+    /// of method-specific annotations, only `IDENTIFIER` is required.
+    Identifier = 8,
 }
 impl FieldBehavior {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -900,6 +913,7 @@ impl FieldBehavior {
             FieldBehavior::Immutable => "IMMUTABLE",
             FieldBehavior::UnorderedList => "UNORDERED_LIST",
             FieldBehavior::NonEmptyDefault => "NON_EMPTY_DEFAULT",
+            FieldBehavior::Identifier => "IDENTIFIER",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -913,6 +927,7 @@ impl FieldBehavior {
             "IMMUTABLE" => Some(Self::Immutable),
             "UNORDERED_LIST" => Some(Self::UnorderedList),
             "NON_EMPTY_DEFAULT" => Some(Self::NonEmptyDefault),
+            "IDENTIFIER" => Some(Self::Identifier),
             _ => None,
         }
     }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

Previously the user is not able to close filter bar and search bar with `Esc` key. This PR fixes it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-627](https://mindvalley.atlassian.net/browse/PXP-627)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

### Fixed
- [x] Close filter bar and search bar with `Esc` key


[PXP-627]: https://mindvalley.atlassian.net/browse/PXP-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ