### PR TITLE
PXP-630: [CLI]: fix ctrl+e panic

### DIFF
--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -420,7 +420,7 @@ fn render_filter_bar<B: Backend>(frame: &mut Frame<'_, B>, input_area: Rect, app
 }
 
 fn calculate_start_position(state: &mut State) -> usize {
-    if state.logs_table_start_position >= state.log_entries.len() {
+    if state.logs_table_start_position > state.log_entries.len() {
         state.logs_table_start_position = state.log_entries.len() - 1;
     }
 

--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -420,8 +420,8 @@ fn render_filter_bar<B: Backend>(frame: &mut Frame<'_, B>, input_area: Rect, app
 }
 
 fn calculate_start_position(state: &mut State) -> usize {
-    if state.logs_table_start_position > state.log_entries.len() {
-        state.logs_table_start_position = state.log_entries.len() - 1;
+    if state.logs_table_start_position >= state.log_entries.len() {
+        state.logs_table_start_position = state.log_entries.len().saturating_sub(1);
     }
 
     state.logs_table_start_position


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary
Sometimes when pressing the Ctrl-e hotkey, the CLI went to panic because the `calculate_start_position` function can result in overflow when `state.logs_table_start_position `exceeds the length of state.log_entries.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: https://mindvalley.atlassian.net/browse/PXP-630

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

### Fixed

- [x] Replaced the direct subtraction of state.logs_table_start_position with the saturating_sub method to ensure that the value stays within a safe range.


