### PR TITLE
PXP-631: [CLI] The header layout is broken on big screen

### DIFF
--- a/cli/src/commands/tui/ui/help.rs
+++ b/cli/src/commands/tui/ui/help.rs
@@ -19,7 +19,7 @@ impl HelpWidget {
             .add_modifier(Modifier::BOLD);
         let desc_style = Style::default().fg(Color::White);
 
-        let rows = app
+        let mut rows = app
             .actions
             .chunks((height - 2) as usize)
             .map(|chunk| {
@@ -35,6 +35,7 @@ impl HelpWidget {
             })
             .collect::<Vec<_>>();
 
+        // for now, we create 3 columns for the hotkey list
         let areas = Layout::default()
             .direction(Direction::Horizontal)
             .constraints(
@@ -50,9 +51,25 @@ impl HelpWidget {
         let middle_border = Borders::TOP | Borders::BOTTOM;
         let last_border = Borders::TOP | Borders::BOTTOM | Borders::RIGHT;
 
-        let rows_len = rows.len();
+        // If the hotkeys list only need less spaces than the available spaces,
+        // add empty `vec![]` to the list so the layout will be draw perfectly.
+        // Otherwise, remove the excess rows so we don't break the layout.
+        if rows.len() < areas.len() {
+            // if `areas.len()` is 3,
+            //    `rows.len()` is 2,
+            // this will add 1 `vec![]` to the `rows`.
+            (0..(areas.len() - rows.len())).for_each(|_| rows.push(vec![]));
+        } else {
+            // if `areas.len()` is 3,
+            //    `rows.len()` is 4,
+            // this will remove 1 `Vec<Row>` frow the `rows`.
+            (0..(rows.len() - areas.len())).for_each(|_| {
+                rows.pop();
+            });
+        }
+
         for (i, row) in rows.into_iter().enumerate() {
-            let block = if i < areas.len() - 1 && i < rows_len - 1 {
+            let block = if i < areas.len() - 1 {
                 Block::default().borders(middle_border)
             } else {
                 Block::default().borders(last_border)
@@ -63,9 +80,7 @@ impl HelpWidget {
                 .widths(&[Constraint::Length(8), Constraint::Min(21)])
                 .column_spacing(1);
 
-            if i < areas.len() {
-                frame.render_widget(widget, areas[i]);
-            }
+            frame.render_widget(widget, areas[i]);
         }
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR fix the header layout issue on big screen.

Before:
<img width="1840" alt="Screenshot 2023-11-03 at 12 02 33 AM" src="https://github.com/mindvalley/wukong-cli/assets/7545747/b0e99624-d6a6-4a6c-a7d1-a1af9e2a8f74">

After: 
<img width="1840" alt="Screenshot 2023-11-03 at 12 05 21 AM" src="https://github.com/mindvalley/wukong-cli/assets/7545747/26b74d2a-8f41-4981-82f2-a55844e8bd31">

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-631](https://mindvalley.atlassian.net/browse/PXP-631)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

### Fixed
- [x] Update the calculation so now the layout is rendered correctly


[PXP-631]: https://mindvalley.atlassian.net/browse/PXP-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ