### PR TITLE
PXP-639: [CLI] Ctrl-e stopped working on the latest codebase

### DIFF
--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -94,7 +94,7 @@ pub struct State {
     // fetch data
     pub builds: Vec<Build>,
     pub deployments: Vec<Deployment>,
-    pub log_entries: Vec<LogEntry>,
+    pub log_entries: (String, Vec<LogEntry>),
     pub log_entries_length: usize,
     pub log_entries_error: Option<String>,
     pub builds_error: Option<String>,
@@ -209,7 +209,10 @@ impl App {
                 last_log_entry_timestamp: None,
 
                 log_entries_length: 0,
-                log_entries: Vec::with_capacity(1_000),
+                log_entries: (
+                    "default".to_string(),
+                    Vec::with_capacity(MAX_LOG_ENTRIES_LENGTH),
+                ),
                 log_entries_error: None,
                 builds_error: None,
                 deployments_error: None,

--- a/cli/src/commands/tui/handlers/logs.rs
+++ b/cli/src/commands/tui/handlers/logs.rs
@@ -120,8 +120,6 @@ pub async fn handler(key: Key, app: &mut App) -> AppReturn {
 }
 
 async fn handle_show_error_and_above(app: &mut App) {
-    app.dispatch(NetworkEvent::GetGCloudLogs).await;
-
     app.state.is_fetching_log_entries = true;
     app.state.start_polling_log_entries = false;
 
@@ -135,6 +133,8 @@ async fn handle_show_error_and_above(app: &mut App) {
         Some(LogSeverity::Error) => None,
         _ => Some(LogSeverity::Error),
     };
+
+    app.dispatch(NetworkEvent::GetGCloudLogs).await;
 }
 
 fn handle_horizontal_scroll(app: &mut App, new_scroll_position: usize) {

--- a/cli/src/commands/tui/handlers/namespace_selection.rs
+++ b/cli/src/commands/tui/handlers/namespace_selection.rs
@@ -1,7 +1,9 @@
+use chrono::Utc;
+
 use super::common_key_events;
 
 use crate::commands::tui::{
-    app::{App, AppReturn, Block},
+    app::{App, AppReturn, Block, MAX_LOG_ENTRIES_LENGTH},
     events::{key::Key, network::NetworkEvent},
 };
 
@@ -39,9 +41,15 @@ async fn handle_enter_key(app: &mut App) {
 }
 
 async fn fetch_and_reset_polling(app: &mut App, selected_version: String) {
+    let new_id = Utc::now().timestamp();
+
+    app.state.log_entries = (
+        format!("{}", new_id),
+        Vec::with_capacity(MAX_LOG_ENTRIES_LENGTH),
+    );
+    app.state.log_entries_length = app.state.log_entries.1.len();
+
     app.state.current_namespace = Some(selected_version);
-    app.state.log_entries = vec![];
-    app.state.log_entries_length = app.state.log_entries.len();
     app.state.last_log_entry_timestamp = None;
 
     app.state.is_fetching_log_entries = true;

--- a/cli/src/commands/tui/handlers/time_filter_selection.rs
+++ b/cli/src/commands/tui/handlers/time_filter_selection.rs
@@ -1,7 +1,9 @@
+use chrono::Utc;
+
 use super::common_key_events;
 
 use crate::commands::tui::{
-    app::{App, AppReturn, Block},
+    app::{App, AppReturn, Block, MAX_LOG_ENTRIES_LENGTH},
     events::key::Key,
 };
 
@@ -41,8 +43,14 @@ async fn handle_enter_key(app: &mut App) {
 }
 
 async fn fetch_and_reset_polling(app: &mut App) {
-    app.state.log_entries = vec![];
-    app.state.log_entries_length = app.state.log_entries.len();
+    let new_id = Utc::now().timestamp();
+
+    app.state.log_entries = (
+        format!("{}", new_id),
+        Vec::with_capacity(MAX_LOG_ENTRIES_LENGTH),
+    );
+    app.state.log_entries_length = app.state.log_entries.1.len();
+
     app.state.last_log_entry_timestamp = None;
 
     // this will trigger refetch of log entries

--- a/cli/src/commands/tui/handlers/version_selection.rs
+++ b/cli/src/commands/tui/handlers/version_selection.rs
@@ -1,7 +1,9 @@
+use chrono::Utc;
+
 use super::common_key_events;
 
 use crate::commands::tui::{
-    app::{App, AppReturn, Block},
+    app::{App, AppReturn, Block, MAX_LOG_ENTRIES_LENGTH},
     events::{key::Key, network::NetworkEvent},
 };
 
@@ -40,9 +42,15 @@ async fn handle_enter_key(app: &mut App) {
 }
 
 async fn fetch_and_reset_polling(app: &mut App, selected_version: String) {
+    let new_id = Utc::now().timestamp();
+
+    app.state.log_entries = (
+        format!("{}", new_id),
+        Vec::with_capacity(MAX_LOG_ENTRIES_LENGTH),
+    );
+    app.state.log_entries_length = app.state.log_entries.1.len();
+
     app.state.current_version = Some(selected_version);
-    app.state.log_entries = vec![];
-    app.state.log_entries_length = app.state.log_entries.len();
     app.state.last_log_entry_timestamp = None;
 
     app.state.is_fetching_log_entries = true;

--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -145,7 +145,7 @@ fn render_log_entries<B: Backend>(frame: &mut Frame<'_, B>, logs_area: Rect, sta
     let num_rows: usize = inner_height as usize;
     let start = state.logs_table_current_start_index;
 
-    let end = std::cmp::min(state.log_entries.len(), start + num_rows);
+    let end = std::cmp::min(state.log_entries.1.len(), start + num_rows);
 
     let log_entries = if state.show_search_bar {
         if state.search_bar_input.input.is_empty() {
@@ -154,13 +154,13 @@ fn render_log_entries<B: Backend>(frame: &mut Frame<'_, B>, logs_area: Rect, sta
             let regex =
                 Regex::new(&format!(r"(?i){}", state.search_bar_input.input.trim())).unwrap();
 
-            filter_log_entries(regex, state.log_entries.iter().collect())
+            filter_log_entries(regex, state.log_entries.1.iter().collect())
         }
     } else if state.show_filter_bar {
         let include = state.filter_bar_include_input.input.clone();
         let exclude = state.filter_bar_exclude_input.input.clone();
 
-        let mut log_entries: Vec<&LogEntry> = state.log_entries.iter().collect();
+        let mut log_entries: Vec<&LogEntry> = state.log_entries.1.iter().collect();
         if !exclude.is_empty() {
             let regex = Regex::new(&format!(r"(?i){}", exclude.trim())).unwrap();
 
@@ -194,7 +194,7 @@ fn render_log_entries<B: Backend>(frame: &mut Frame<'_, B>, logs_area: Rect, sta
         let mut first_color = true;
         let mut is_fully_filled = false;
 
-        for (i, log) in state.log_entries[start..end].iter().enumerate() {
+        for (i, log) in state.log_entries.1[start..end].iter().enumerate() {
             let color = if first_color {
                 Color::Cyan
             } else {
@@ -366,7 +366,7 @@ fn generate_log_entries_line_without_text_wrap(
     // ) -> Vec<Row> {
     let mut first_color = true;
 
-    state.log_entries[start..end]
+    state.log_entries.1[start..end]
         .iter()
         .map(|log_entry| {
             let color = if first_color {

--- a/cli/src/output/tokenizer.rs
+++ b/cli/src/output/tokenizer.rs
@@ -188,7 +188,7 @@ impl OutputTokenizer {
                 }
             } else {
                 // this is more readable
-                #[allow(clippy::collapsible-else-if)]
+                #[allow(clippy::collapsible_else_if)]
                 if word.contains('(') {
                     let open_index = word.find('(').unwrap();
                     tokens.push(Token::Parentheses("(".to_string()));

--- a/sdk/src/services/vault/client.rs
+++ b/sdk/src/services/vault/client.rs
@@ -57,8 +57,8 @@ impl Default for VaultClient {
 }
 
 impl VaultClient {
-    pub const FETCH_SECRETS: &str = "/v1/secret/data";
-    pub const UPDATE_SECRET: &str = "/v1/secret/data";
+    pub const FETCH_SECRETS: &'static str = "/v1/secret/data";
+    pub const UPDATE_SECRET: &'static str = "/v1/secret/data";
 
     pub fn new() -> Self {
         let client = reqwest::Client::new();


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-639](https://mindvalley.atlassian.net/browse/PXP-639)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

### Changed
- [x] Add an ID to determine whether the API response is outdated or not
For example, the `log_entries` type is `(String, Vec<LogEntry>)`, the first value is the ID. Every time the state is changed (Namespace, version, time filter, log severity and etc), a new ID will be generated. And if the API ID is not the same with the latest ID, it won't append to the `Vec`. This prevent the existing outdated API call results pollute the log vector.


<!-- ### Fixed -->


[PXP-639]: https://mindvalley.atlassian.net/browse/PXP-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ