### PR TITLE
PXP-640: [CLI] Log panel panic when the start index out of bound

### DIFF
--- a/cli/src/commands/tui/handlers/empty.rs
+++ b/cli/src/commands/tui/handlers/empty.rs
@@ -1,12 +1,14 @@
 use crate::commands::tui::{
     action::Action,
-    app::{App, AppReturn, Block, DialogContext, MAX_LOG_ENTRIES_LENGTH},
-    events::{key::Key, network::NetworkEvent},
+    app::{App, AppReturn, Block, DialogContext},
+    events::key::Key,
 };
-use chrono::Utc;
 use wukong_sdk::services::gcloud::google::logging::r#type::LogSeverity;
 
-use super::{common_key_events, log_filter_exclude, log_filter_include, log_search};
+use super::{
+    common_key_events, log_filter_exclude, log_filter_include, log_search,
+    logs::reset_log_panel_and_trigger_log_refetch,
+};
 
 // In the absence of an selected block, handle standard events as usual.
 pub async fn handler(key: Key, app: &mut App) -> AppReturn {
@@ -118,19 +120,6 @@ fn open_dialog(app: &mut App, dialog_context: DialogContext) -> AppReturn {
 }
 
 async fn show_error_and_above_logs(app: &mut App) -> AppReturn {
-    let new_id = Utc::now().timestamp();
-
-    app.state.log_entries = (
-        format!("{}", new_id),
-        Vec::with_capacity(MAX_LOG_ENTRIES_LENGTH),
-    );
-    app.state.log_entries_length = 0;
-
-    app.state.is_fetching_log_entries = true;
-    app.state.start_polling_log_entries = false;
-
-    // Need to reset scroll, or else it will be out of bound
-
     // Add if not already in the list
     // or else remove it
     app.state.logs_severity = match app.state.logs_severity {
@@ -138,7 +127,7 @@ async fn show_error_and_above_logs(app: &mut App) -> AppReturn {
         _ => Some(LogSeverity::Error),
     };
 
-    app.dispatch(NetworkEvent::GetGCloudLogs).await;
+    reset_log_panel_and_trigger_log_refetch(app);
 
     AppReturn::Continue
 }

--- a/cli/src/commands/tui/handlers/namespace_selection.rs
+++ b/cli/src/commands/tui/handlers/namespace_selection.rs
@@ -1,9 +1,7 @@
-use chrono::Utc;
-
-use super::common_key_events;
+use super::{common_key_events, logs::reset_log_panel_and_trigger_log_refetch};
 
 use crate::commands::tui::{
-    app::{App, AppReturn, Block, MAX_LOG_ENTRIES_LENGTH},
+    app::{App, AppReturn, Block},
     events::{key::Key, network::NetworkEvent},
 };
 
@@ -41,22 +39,8 @@ async fn handle_enter_key(app: &mut App) {
 }
 
 async fn fetch_and_reset_polling(app: &mut App, selected_version: String) {
-    let new_id = Utc::now().timestamp();
-
-    app.state.log_entries = (
-        format!("{}", new_id),
-        Vec::with_capacity(MAX_LOG_ENTRIES_LENGTH),
-    );
-    app.state.log_entries_length = app.state.log_entries.1.len();
-
     app.state.current_namespace = Some(selected_version);
-    app.state.last_log_entry_timestamp = None;
-
-    app.state.is_fetching_log_entries = true;
-    app.state.start_polling_log_entries = false;
-
-    // reset error state
-    app.state.log_entries_error = None;
+    reset_log_panel_and_trigger_log_refetch(app);
 
     app.dispatch(NetworkEvent::GetBuilds).await;
 }

--- a/cli/src/commands/tui/handlers/time_filter_selection.rs
+++ b/cli/src/commands/tui/handlers/time_filter_selection.rs
@@ -1,9 +1,7 @@
-use chrono::Utc;
-
-use super::common_key_events;
+use super::{common_key_events, logs::reset_log_panel_and_trigger_log_refetch};
 
 use crate::commands::tui::{
-    app::{App, AppReturn, Block, MAX_LOG_ENTRIES_LENGTH},
+    app::{App, AppReturn, Block},
     events::key::Key,
 };
 
@@ -32,31 +30,12 @@ async fn handle_enter_key(app: &mut App) {
     if let Some(current_time_filter) = &app.state.current_time_filter {
         if current_time_filter != selected {
             app.state.current_time_filter = Some(*selected);
-            fetch_and_reset_polling(app).await;
+            reset_log_panel_and_trigger_log_refetch(app);
         }
     } else {
         app.state.current_time_filter = Some(*selected);
-        fetch_and_reset_polling(app).await;
+        reset_log_panel_and_trigger_log_refetch(app);
     }
 
     app.push_navigation_stack(Block::Log)
-}
-
-async fn fetch_and_reset_polling(app: &mut App) {
-    let new_id = Utc::now().timestamp();
-
-    app.state.log_entries = (
-        format!("{}", new_id),
-        Vec::with_capacity(MAX_LOG_ENTRIES_LENGTH),
-    );
-    app.state.log_entries_length = app.state.log_entries.1.len();
-
-    app.state.last_log_entry_timestamp = None;
-
-    // this will trigger refetch of log entries
-    app.state.is_fetching_log_entries = true;
-    app.state.start_polling_log_entries = false;
-
-    // reset error state
-    app.state.log_entries_error = None;
 }

--- a/cli/src/commands/tui/handlers/version_selection.rs
+++ b/cli/src/commands/tui/handlers/version_selection.rs
@@ -1,9 +1,7 @@
-use chrono::Utc;
-
-use super::common_key_events;
+use super::{common_key_events, logs::reset_log_panel_and_trigger_log_refetch};
 
 use crate::commands::tui::{
-    app::{App, AppReturn, Block, MAX_LOG_ENTRIES_LENGTH},
+    app::{App, AppReturn, Block},
     events::{key::Key, network::NetworkEvent},
 };
 
@@ -42,22 +40,8 @@ async fn handle_enter_key(app: &mut App) {
 }
 
 async fn fetch_and_reset_polling(app: &mut App, selected_version: String) {
-    let new_id = Utc::now().timestamp();
-
-    app.state.log_entries = (
-        format!("{}", new_id),
-        Vec::with_capacity(MAX_LOG_ENTRIES_LENGTH),
-    );
-    app.state.log_entries_length = app.state.log_entries.1.len();
-
     app.state.current_version = Some(selected_version);
-    app.state.last_log_entry_timestamp = None;
-
-    app.state.is_fetching_log_entries = true;
-    app.state.start_polling_log_entries = false;
-
-    // reset error state
-    app.state.log_entries_error = None;
+    reset_log_panel_and_trigger_log_refetch(app);
 
     app.dispatch(NetworkEvent::GetBuilds).await;
 }

--- a/cli/src/commands/tui/ui/logs.rs
+++ b/cli/src/commands/tui/ui/logs.rs
@@ -143,7 +143,10 @@ fn render_log_entries<B: Backend>(frame: &mut Frame<'_, B>, logs_area: Rect, sta
     state.logs_size = (inner_width, inner_height);
 
     let num_rows: usize = inner_height as usize;
-    let start = state.logs_table_current_start_index;
+    let start = std::cmp::min(
+        state.log_entries.1.len(),
+        state.logs_table_current_start_index,
+    );
 
     let end = std::cmp::min(state.log_entries.1.len(), start + num_rows);
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-640](https://mindvalley.atlassian.net/browse/PXP-640)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

### Fixed
- [x] reset the `logs_table_current_start_index` and `logs_table_current_last_index` whenever the state is changed
- [x] reset the `last_log_entry_timestamp` whenever the state is changed so now it will fetch with the correct time filter when the log severity is changed

[PXP-640]: https://mindvalley.atlassian.net/browse/PXP-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ