### PR TITLE
PXP-633: Better error handling if there is failure on JSON decode 

### DIFF
--- a/sdk/src/graphql/mod.rs
+++ b/sdk/src/graphql/mod.rs
@@ -134,14 +134,18 @@ impl GQLClient {
         let request = self.inner.post(url.clone()).json(&body);
         debug!("request: {:#?}", request);
 
-        let response: Response<Q::ResponseData>=
-            request.send().await?.json().await.map_err(|err: reqwest::Error| {
-                debug!("response: {:#?}", err);
-                return APIError::MissingResponseData;
-              })?;
+        let response: Response<Q::ResponseData> =
+            request
+                .send()
+                .await?
+                .json()
+                .await
+                .map_err(|err: reqwest::Error| {
+                    debug!("response: {:#?}", err);
+                    APIError::MissingResponseData
+                })?;
 
         debug!("response: {:#?}", response);
-
 
         // We use <= 3 so it does one extra loop where the last response is checked
         // in order to return an APIError::Timeout if it was a timeout error in the

--- a/sdk/src/graphql/mod.rs
+++ b/sdk/src/graphql/mod.rs
@@ -134,8 +134,14 @@ impl GQLClient {
         let request = self.inner.post(url.clone()).json(&body);
         debug!("request: {:#?}", request);
 
-        let response: Response<Q::ResponseData> = request.send().await?.json().await?;
+        let response: Response<Q::ResponseData>=
+            request.send().await?.json().await.map_err(|err: reqwest::Error| {
+                debug!("response: {:#?}", err);
+                return APIError::MissingResponseData;
+              })?;
+
         debug!("response: {:#?}", response);
+
 
         // We use <= 3 so it does one extra loop where the last response is checked
         // in order to return an APIError::Timeout if it was a timeout error in the


### PR DESCRIPTION
Currently the Wukong CLI is expecting a proper response which are defined on the grapql schema. If the response is diff it throws an error with this error
`Error - error decoding response body: expected value at line 1 column 1`

I've handled this and throw `MissingResponseData` instead to make it more readable to the end user

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: https://mindvalley.atlassian.net/browse/PXP-633

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->


<!-- ### Changed -->
- [x] Additional handling for json decoding error

<!-- ### Fixed -->
