### PR TITLE
PXP-641: Handle event sender panic

### DIFF
--- a/cli/src/commands/tui/events/mod.rs
+++ b/cli/src/commands/tui/events/mod.rs
@@ -61,7 +61,9 @@ impl EventManager {
                     }
                 }
 
-                event_sender.send(Event::Tick).unwrap();
+                if event_sender.send(Event::Tick).is_err() {
+                    break;
+                }
             }
         });
     }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

CLI crashed when sender event is not able to send the event to the event manager. To fix that used `is_error` instead of unwarp to gracefully handle the error

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: https://mindvalley.atlassian.net/browse/PXP-641

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

- [x] Update the event_sender to use `is_error` instead of `unwrap`

<!-- ### Fixed -->
