### PR TITLE
PXP-638: [CLI] Implement new config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "arrayvec"
@@ -4540,9 +4540,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
@@ -4568,9 +4568,9 @@ checksum = "3e32d019b4f7c100bcd5494e40a27119d45b71fba2b07a4684153129279a4647"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
  "time-core",
 ]
@@ -5457,6 +5457,7 @@ name = "wukong"
 version = "2.0.1"
 dependencies = [
  "aion",
+ "anyhow",
  "assert_cmd",
  "assert_fs",
  "base64 0.21.5",
@@ -5496,6 +5497,7 @@ dependencies = [
  "tabled",
  "textwrap 0.16.0",
  "thiserror",
+ "time",
  "time-humanize",
  "tokio",
  "toml",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -62,6 +62,8 @@ semver = "1.0.20"
 # Telemetry
 wukong-telemetry-macro = { path = "../telemetry-macro" }
 wukong-telemetry = { path = "../telemetry" }
+time = { version = "0.3.31", features = ["formatting", "parsing"] }
+anyhow = "1.0.79"
 
 [dev-dependencies]
 httpmock = "0.6.7"

--- a/cli/src/auth/google_cloud.rs
+++ b/cli/src/auth/google_cloud.rs
@@ -114,7 +114,7 @@ impl TokenStorage for ConfigTokenStore {
     }
 }
 
-pub async fn get_token_or_login() -> String {
+pub async fn get_token_or_login(config: Option<Config>) -> String {
     let secret = ApplicationSecret {
         client_id: GOOGLE_CLIENT_ID.to_string(),
         client_secret: GOOGLE_CLIENT_SECRET.to_string(),
@@ -136,7 +136,10 @@ pub async fn get_token_or_login() -> String {
             .build(),
     );
 
-    let config = Config::load_from_default_path().expect("Unable to load config");
+    let config = match config {
+        Some(config) => config,
+        None => Config::load_from_default_path().expect("Unable to load config"),
+    };
 
     let authenticator = InstalledFlowAuthenticator::with_client(
         secret,
@@ -167,7 +170,7 @@ pub async fn get_access_token() -> Option<String> {
     // Sometimes access token exist but is expired, so call get_token_or_login() to refresh it
     // before returning it.
     if config.auth.google_cloud.is_some() {
-        Some(get_token_or_login().await)
+        Some(get_token_or_login(None).await)
     } else {
         None
     }

--- a/cli/src/auth/google_cloud.rs
+++ b/cli/src/auth/google_cloud.rs
@@ -87,7 +87,7 @@ impl TokenStorage for ConfigTokenStore {
             expiry_time: token
                 .expires_at
                 .expect("Invalid expiry time")
-                .format(&format_description::well_known::Iso8601::DEFAULT)?,
+                .format(&format_description::well_known::Rfc3339)?,
             id_token: token.id_token,
         });
 
@@ -105,7 +105,7 @@ impl TokenStorage for ConfigTokenStore {
             expires_at: Some(
                 OffsetDateTime::parse(
                     &google_cloud.expiry_time,
-                    &format_description::well_known::Iso8601::DEFAULT,
+                    &format_description::well_known::Rfc3339,
                 )
                 .expect("Invalid expiry time"),
             ),

--- a/cli/src/auth/google_cloud.rs
+++ b/cli/src/auth/google_cloud.rs
@@ -1,10 +1,12 @@
-use once_cell::sync::Lazy;
+use crate::config::Config;
 use serde::{Deserialize, Serialize};
 use std::{future::Future, pin::Pin};
+use time::{format_description, OffsetDateTime};
+use tonic::async_trait;
 use yup_oauth2::{
     authenticator_delegate::{DefaultInstalledFlowDelegate, InstalledFlowDelegate},
     hyper, hyper_rustls,
-    storage::TokenInfo,
+    storage::{TokenInfo, TokenStorage},
     ApplicationSecret, InstalledFlowAuthenticator, InstalledFlowReturnMethod,
 };
 
@@ -13,25 +15,6 @@ struct JSONToken {
     scopes: Vec<String>,
     token: TokenInfo,
 }
-
-pub static CONFIG_PATH: Lazy<Option<String>> = Lazy::new(|| {
-    #[cfg(feature = "prod")]
-    return dirs::home_dir().map(|mut path| {
-        path.extend([".config", "wukong"]);
-        path.to_str().unwrap().to_string()
-    });
-
-    #[cfg(not(feature = "prod"))]
-    {
-        match std::env::var("WUKONG_DEV_GCLOUD_FILE") {
-            Ok(config) => Some(config),
-            Err(_) => dirs::home_dir().map(|mut path| {
-                path.extend([".config", "wukong", "dev"]);
-                path.to_str().unwrap().to_string()
-            }),
-        }
-    }
-});
 
 /// async function to be pinned by the `present_user_url` method of the trait
 /// we use the existing `DefaultInstalledFlowDelegate::present_user_url` method as a fallback for
@@ -74,6 +57,63 @@ const AUTH_URI: &str = "https://accounts.google.com/o/oauth2/auth";
 const REDIRECT_URI: &str = "http://127.0.0.1/8855";
 const AUTH_PROVIDER_X509_CERT_URL: &str = "https://www.googleapis.com/oauth2/v1/certs";
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct GoogleCloudConfig {
+    /// used when authorizing calls to oauth2 enabled services.
+    pub access_token: String,
+    /// used to refresh an expired access_token.
+    pub refresh_token: String,
+    /// The time when the token expires.
+    pub expiry_time: String,
+    /// Optionally included by the OAuth2 server and may contain information to verify the identity
+    /// used to obtain the access token.
+    /// Specifically Google API:s include this if the additional scopes "email" and/or "profile"
+    /// are used. In that case the content is an JWT token.
+    pub id_token: Option<String>,
+}
+
+struct ConfigTokenStore {
+    config: Config,
+}
+
+#[async_trait]
+impl TokenStorage for ConfigTokenStore {
+    async fn set(&self, _scopes: &[&str], token: TokenInfo) -> anyhow::Result<()> {
+        let mut config = self.config.clone();
+
+        config.google_cloud = Some(GoogleCloudConfig {
+            access_token: token.access_token.expect("Invalid access token"),
+            refresh_token: token.refresh_token.expect("Invalid refresh token"),
+            expiry_time: token
+                .expires_at
+                .expect("Invalid expiry time")
+                .format(&format_description::well_known::Iso8601::DEFAULT)?,
+            id_token: token.id_token,
+        });
+
+        config.save_to_default_path()?;
+
+        Ok(())
+    }
+
+    async fn get(&self, _target_scopes: &[&str]) -> Option<TokenInfo> {
+        let google_cloud = self.config.google_cloud.clone()?;
+
+        Some(TokenInfo {
+            access_token: Some(google_cloud.access_token),
+            refresh_token: Some(google_cloud.refresh_token),
+            expires_at: Some(
+                OffsetDateTime::parse(
+                    &google_cloud.expiry_time,
+                    &format_description::well_known::Iso8601::DEFAULT,
+                )
+                .expect("Invalid expiry time"),
+            ),
+            id_token: google_cloud.id_token,
+        })
+    }
+}
+
 pub async fn get_token_or_login() -> String {
     let secret = ApplicationSecret {
         client_id: GOOGLE_CLIENT_ID.to_string(),
@@ -96,17 +136,14 @@ pub async fn get_token_or_login() -> String {
             .build(),
     );
 
+    let config = Config::load_from_default_path().expect("Unable to load config");
+
     let authenticator = InstalledFlowAuthenticator::with_client(
         secret,
         InstalledFlowReturnMethod::HTTPPortRedirect(8855),
         client,
     )
-    .persist_tokens_to_disk(format!(
-        "{}/gcloud_logging",
-        CONFIG_PATH
-            .as_ref()
-            .expect("Unable to identify user's home directory"),
-    ))
+    .with_storage(Box::new(ConfigTokenStore { config }))
     .flow_delegate(Box::new(InstalledFlowBrowserDelegate))
     .build()
     .await
@@ -122,38 +159,14 @@ pub async fn get_token_or_login() -> String {
 }
 
 pub async fn get_access_token() -> Option<String> {
-    let contents = tokio::fs::read(format!(
-        "{}/gcloud_logging",
-        CONFIG_PATH
-            .as_ref()
-            .expect("Unable to identify user's home directory")
-    ))
-    .await;
-
-    let tokens = contents
-        .map(|contents| {
-            serde_json::from_slice::<Vec<JSONToken>>(&contents)
-                .map_err(|_| {
-                    eprintln!("Failed to parse token file.");
-                })
-                .ok()
-        })
-        .unwrap_or(None);
-
-    let json_token = tokens.and_then(|tokens| {
-        tokens
-            .iter()
-            .find(|token| {
-                token
-                    .scopes
-                    .contains(&"https://www.googleapis.com/auth/logging.read".to_string())
-            })
-            .map(|token| token.token.access_token.clone())
-    });
+    let config = match Config::load_from_default_path() {
+        Ok(config) => config,
+        Err(_) => return None,
+    };
 
     // Sometimes access token exist but is expired, so call get_token_or_login() to refresh it
     // before returning it.
-    if json_token.is_some() {
+    if config.google_cloud.is_some() {
         Some(get_token_or_login().await)
     } else {
         None

--- a/cli/src/auth/google_cloud.rs
+++ b/cli/src/auth/google_cloud.rs
@@ -81,7 +81,7 @@ impl TokenStorage for ConfigTokenStore {
     async fn set(&self, _scopes: &[&str], token: TokenInfo) -> anyhow::Result<()> {
         let mut config = self.config.clone();
 
-        config.google_cloud = Some(GoogleCloudConfig {
+        config.auth.google_cloud = Some(GoogleCloudConfig {
             access_token: token.access_token.expect("Invalid access token"),
             refresh_token: token.refresh_token.expect("Invalid refresh token"),
             expiry_time: token
@@ -97,7 +97,7 @@ impl TokenStorage for ConfigTokenStore {
     }
 
     async fn get(&self, _target_scopes: &[&str]) -> Option<TokenInfo> {
-        let google_cloud = self.config.google_cloud.clone()?;
+        let google_cloud = self.config.auth.google_cloud.clone()?;
 
         Some(TokenInfo {
             access_token: Some(google_cloud.access_token),
@@ -166,7 +166,7 @@ pub async fn get_access_token() -> Option<String> {
 
     // Sometimes access token exist but is expired, so call get_token_or_login() to refresh it
     // before returning it.
-    if config.google_cloud.is_some() {
+    if config.auth.google_cloud.is_some() {
         Some(get_token_or_login().await)
     } else {
         None

--- a/cli/src/auth/okta.rs
+++ b/cli/src/auth/okta.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{AuthConfig, Config},
+    config::{Config, OktaConfig},
     error::{AuthError, WKCliError},
     utils::compare_with_current_time,
 };
@@ -53,7 +53,7 @@ pub struct OktaAuth {
     pub expiry_time: String,
 }
 
-impl From<OktaAuth> for AuthConfig {
+impl From<OktaAuth> for OktaConfig {
     fn from(value: OktaAuth) -> Self {
         Self {
             account: value.account,

--- a/cli/src/auth/vault.rs
+++ b/cli/src/auth/vault.rs
@@ -105,7 +105,7 @@ pub async fn get_token_or_login(config: &mut Config) -> Result<String, WKCliErro
                 });
                 config.save_to_default_path()?;
 
-                colored_println!("You are now logged in as {}.\n", email);
+                colored_println!("You are now logged in as: {}.\n", email);
                 Ok(login_resp.auth.client_token)
             }
             Err(err) => Err(err),
@@ -134,7 +134,7 @@ pub async fn get_token_or_login(config: &mut Config) -> Result<String, WKCliErro
             });
             config.save_to_default_path()?;
 
-            colored_println!("You are now logged in as {}.\n", email);
+            colored_println!("You are now logged in as: {}.\n", email);
             Ok(login_resp.auth.client_token)
         }
     }

--- a/cli/src/commands/application/logs.rs
+++ b/cli/src/commands/application/logs.rs
@@ -32,7 +32,7 @@ pub async fn handle_logs(
     auth_loader.set_message("Checking if you're authenticated to Google Cloud...");
 
     let config = Config::load_from_default_path()?;
-    let gcloud_access_token = auth::google_cloud::get_token_or_login().await;
+    let gcloud_access_token = auth::google_cloud::get_token_or_login(None).await;
     let mut wk_client = WKClient::for_channel(&config, &context.channel)?;
 
     auth_loader.finish_and_clear();

--- a/cli/src/commands/google/login.rs
+++ b/cli/src/commands/google/login.rs
@@ -4,8 +4,7 @@ pub async fn handle_login() -> Result<bool, WKCliError> {
     let loader = new_spinner();
     loader.set_message("Logging in to Google Cloud ...");
 
-    let test = auth::google_cloud::get_token_or_login().await;
-    println!("{:?}", test);
+    auth::google_cloud::get_token_or_login().await;
 
     loader.finish_with_message(
         "Successfully logged in to Google Cloud. You can now use Wukong to manage your Google Cloud resources.\n",

--- a/cli/src/commands/google/login.rs
+++ b/cli/src/commands/google/login.rs
@@ -4,10 +4,11 @@ pub async fn handle_login() -> Result<bool, WKCliError> {
     let loader = new_spinner();
     loader.set_message("Logging in to Google Cloud ...");
 
-    auth::google_cloud::get_token_or_login().await;
+    let test = auth::google_cloud::get_token_or_login().await;
+    println!("{:?}", test);
 
     loader.finish_with_message(
-        "Successfully logged in to Google Cloud. You can now use Wukong to manage your Google Cloud resources.",
+        "Successfully logged in to Google Cloud. You can now use Wukong to manage your Google Cloud resources.\n",
     );
 
     Ok(true)

--- a/cli/src/commands/google/login.rs
+++ b/cli/src/commands/google/login.rs
@@ -1,11 +1,10 @@
-use crate::{auth, error::WKCliError, loader::new_spinner};
+use crate::{auth, config::Config, error::WKCliError, loader::new_spinner};
 
-pub async fn handle_login() -> Result<bool, WKCliError> {
+pub async fn handle_login(config: Option<Config>) -> Result<bool, WKCliError> {
     let loader = new_spinner();
     loader.set_message("Logging in to Google Cloud ...");
 
-    auth::google_cloud::get_token_or_login().await;
-
+    auth::google_cloud::get_token_or_login(config).await;
     loader.finish_with_message(
         "Successfully logged in to Google Cloud. You can now use Wukong to manage your Google Cloud resources.\n",
     );

--- a/cli/src/commands/google/mod.rs
+++ b/cli/src/commands/google/mod.rs
@@ -20,7 +20,7 @@ pub enum GoogleSubcommand {
 impl Google {
     pub async fn handle_command(&self) -> Result<bool, WKCliError> {
         match &self.subcommand {
-            GoogleSubcommand::Login => handle_login().await,
+            GoogleSubcommand::Login => handle_login(None).await,
         }
     }
 }

--- a/cli/src/commands/google/mod.rs
+++ b/cli/src/commands/google/mod.rs
@@ -3,7 +3,7 @@ use clap::{Args, Subcommand};
 use std::str;
 
 use self::login::handle_login;
-mod login;
+pub mod login;
 
 #[derive(Debug, Args)]
 pub struct Google {

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,13 +1,12 @@
 use crate::{
-    auth,
+    commands::login::handle_login,
     config::{ApiChannel, Config},
-    error::{AuthError, ConfigError, WKCliError},
+    error::{ConfigError, WKCliError},
     loader::new_spinner,
     output::colored_println,
     wukong_client::WKClient,
 };
 use dialoguer::{theme::ColorfulTheme, Select};
-use log::debug;
 
 pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
     println!("Welcome! This command will take you through the configuration of Wukong.\n");
@@ -21,56 +20,9 @@ pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
         },
     };
 
-    let mut login_selections = vec!["Log in with a new account"];
-    if let Some(ref auth_config) = config.auth {
-        login_selections.splice(..0, vec![auth_config.account.as_str()]);
-    };
+    handle_login(Some(config)).await?;
 
-    let selection = Select::with_theme(&ColorfulTheme::default())
-                .with_prompt("Choose the account you would like to use to perform operations for this configuration:")
-                .default(0)
-                .items(&login_selections[..])
-                .interact()?;
-
-    // "Log in with a new account" is selected
-    let mut new_config = if selection == login_selections.len() - 1 {
-        login_and_create_config(Config::default()).await?
-    } else {
-        // check access token expiry
-        let mut current_config = config.clone();
-
-        if auth::okta::need_tokens_refresh(&config)? {
-            debug!("Access token expired. Refreshing tokens...");
-
-            let refresh_token_loader = new_spinner();
-            refresh_token_loader.set_message("Refreshing tokens...");
-
-            let updated_config = match auth::okta::refresh_tokens(&config).await {
-                Ok(new_tokens) => {
-                    current_config.auth = Some(new_tokens.into());
-                    refresh_token_loader.finish_and_clear();
-
-                    current_config
-                }
-                Err(err) => {
-                    refresh_token_loader.finish_and_clear();
-                    match err {
-                        WKCliError::AuthError(AuthError::OktaRefreshTokenExpired { .. }) => {
-                            eprintln!("The refresh token is expired. You have to login again.");
-                            login_and_create_config(current_config).await?
-                        }
-                        err => return Err(err),
-                    }
-                }
-            };
-
-            current_config = updated_config;
-        } else {
-            colored_println!("You are logged in as: {}.\n", login_selections[selection]);
-        }
-
-        current_config
-    };
+    let mut new_config = Config::load_from_default_path()?;
 
     let fetch_loader = new_spinner();
     fetch_loader.set_message("Fetching application list...");
@@ -102,16 +54,16 @@ pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
 
     colored_println!(
         r#"
-Your Wukong CLI is configured and ready to use!
+    Your Wukong CLI is configured and ready to use!
 
-* Commands that require authentication will use {} by default
-* Commands will reference application {} by default
-Run `wukong config help` to learn how to change individual settings
+    * Commands that require authentication will use {} by default
+    * Commands will reference application {} by default
+    Run `wukong config help` to learn how to change individual settings
 
-Some things to try next:
+    Some things to try next:
 
-* Run `wukong --help` to see the wukong command groups you can interact with. And run `wukong COMMAND help` to get help on any wukong command.
-                         "#,
+    * Run `wukong --help` to see the wukong command groups you can interact with. And run `wukong COMMAND help` to get help on any wukong command.
+                             "#,
         new_config.auth.as_ref().unwrap().account,
         new_config.core.application
     );
@@ -121,15 +73,4 @@ Some things to try next:
         .expect("Config file save failed");
 
     Ok(true)
-}
-
-async fn login_and_create_config(mut config: Config) -> Result<Config, WKCliError> {
-    let auth_info = auth::okta::login(&config).await?;
-    let acc = auth_info.account.clone();
-
-    config.auth = Some(auth_info.into());
-
-    colored_println!("You are logged in as: {acc}.\n");
-
-    Ok(config)
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -60,7 +60,7 @@ async fn handle_bunker_auth(mut config: Config) -> Result<Config, WKCliError> {
             "(Optional)".bright_black(),
             "Do you want to authenticate against Bunker? You may do it later when neccessary"
         ))
-        .default(true)
+        .default(false)
         .interact()?;
 
     if agree_to_authenticate {

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -28,7 +28,7 @@ pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
     let mut new_config = Config::load_from_default_path()?;
     new_config = handle_application(new_config, channel).await?;
     new_config = handle_gcloud_auth(new_config).await?;
-    new_config = handle_bunker_auth(new_config).await?;
+    new_config = handle_vault_auth(new_config).await?;
 
     colored_println!(
         r#"
@@ -53,7 +53,7 @@ pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
     Ok(true)
 }
 
-async fn handle_bunker_auth(mut config: Config) -> Result<Config, WKCliError> {
+async fn handle_vault_auth(mut config: Config) -> Result<Config, WKCliError> {
     let agree_to_authenticate = Confirm::with_theme(&ColorfulTheme::default())
         .with_prompt(format!(
             "{} {}",

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -41,15 +41,15 @@ pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
 
     colored_println!(
         r#"
-    Your Wukong CLI is configured and ready to use!
+Your Wukong CLI is configured and ready to use!
 
-    * Commands that require authentication will use {} by default
-    * Commands will reference application {} by default
-    Run `wukong config help` to learn how to change individual settings
+* Commands that require authentication will use {} by default
+* Commands will reference application {} by default
+Run `wukong config help` to learn how to change individual settings
 
-    Some things to try next:
+Some things to try next:
 
-    * Run `wukong --help` to see the wukong command groups you can interact with. And run `wukong COMMAND help` to get help on any wukong command.
+* Run `wukong --help` to see the wukong command groups you can interact with. And run `wukong COMMAND help` to get help on any wukong command.
                              "#,
         config.auth.okta.as_ref().unwrap().account,
         config.core.application

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -70,7 +70,7 @@ async fn handle_bunker_auth(mut config: Config) -> Result<Config, WKCliError> {
     Ok(config)
 }
 
-async fn handle_gcloud_auth(new_config: Config) -> Result<Config, WKCliError> {
+async fn handle_gcloud_auth(config: Config) -> Result<Config, WKCliError> {
     let agree_to_authenticate = Confirm::with_theme(&ColorfulTheme::default())
         .with_prompt(format!(
             "{} {}",
@@ -83,11 +83,11 @@ async fn handle_gcloud_auth(new_config: Config) -> Result<Config, WKCliError> {
     if agree_to_authenticate {
         google::login::handle_login().await?;
         // Load the config again to get the latest token
-        let new_config = Config::load_from_default_path()?;
-        return Ok(new_config);
+        let updated_config = Config::load_from_default_path()?;
+        return Ok(updated_config);
     }
 
-    Ok(new_config)
+    Ok(config)
 }
 
 async fn handle_application(mut config: Config, channel: ApiChannel) -> Result<Config, WKCliError> {

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -42,7 +42,7 @@ pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
 
     * Run `wukong --help` to see the wukong command groups you can interact with. And run `wukong COMMAND help` to get help on any wukong command.
                              "#,
-        new_config.auth.as_ref().unwrap().account,
+        new_config.auth.okta.as_ref().unwrap().account,
         new_config.core.application
     );
 

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -82,6 +82,9 @@ async fn handle_gcloud_auth(new_config: Config) -> Result<Config, WKCliError> {
 
     if agree_to_authenticate {
         google::login::handle_login().await?;
+        // Load the config again to get the latest token
+        let new_config = Config::load_from_default_path()?;
+        return Ok(new_config);
     }
 
     Ok(new_config)

--- a/cli/src/commands/login.rs
+++ b/cli/src/commands/login.rs
@@ -15,8 +15,8 @@ pub async fn handle_login(config: Option<Config>) -> Result<bool, WKCliError> {
     };
 
     let mut login_selections = vec!["Log in with a new account"];
-    if let Some(ref auth_config) = config.auth {
-        login_selections.splice(..0, vec![auth_config.account.as_str()]);
+    if let Some(ref okta_config) = config.auth.okta {
+        login_selections.splice(..0, vec![okta_config.account.as_str()]);
     };
 
     let selected_account = Select::with_theme(&ColorfulTheme::default())
@@ -39,7 +39,7 @@ pub async fn handle_login(config: Option<Config>) -> Result<bool, WKCliError> {
 
             let updated_config = match auth::okta::refresh_tokens(&config).await {
                 Ok(new_tokens) => {
-                    current_config.auth = Some(new_tokens.into());
+                    current_config.auth.okta = Some(new_tokens.into());
 
                     refresh_token_loader.finish_and_clear();
                     colored_println!(
@@ -81,7 +81,7 @@ async fn login_and_create_config(mut config: Config) -> Result<Config, WKCliErro
     let auth_info = auth::okta::login(&config).await?;
     let acc = auth_info.account.clone();
 
-    config.auth = Some(auth_info.into());
+    config.auth.okta = Some(auth_info.into());
 
     colored_println!("You are logged in as: {acc}.\n");
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -120,7 +120,7 @@ impl ClapApp {
         let command = match &self.command_group {
             CommandGroup::Init => handle_init(channel).await,
             CommandGroup::Completion { shell } => handle_completion(*shell),
-            CommandGroup::Login => handle_login(None).await,
+            CommandGroup::Login => handle_login().await,
             CommandGroup::Google(google) => google.handle_command().await,
             CommandGroup::Application(application) => {
                 application.handle_command(get_context(self)?).await

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -157,7 +157,7 @@ fn get_context(clap_app: &ClapApp) -> Result<Context, WKCliError> {
                 config.core.application
             }
         },
-        sub: config.auth.map(|auth_config| auth_config.subject),
+        sub: config.auth.okta.map(|auth_config| auth_config.subject),
         // if the `--canary` flag is used, then the CLI will use the Canary channel API,
         // otherwise, it will use the Stable channel API.
         channel: if clap_app.canary {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -120,7 +120,7 @@ impl ClapApp {
         let command = match &self.command_group {
             CommandGroup::Init => handle_init(channel).await,
             CommandGroup::Completion { shell } => handle_completion(*shell),
-            CommandGroup::Login => handle_login().await,
+            CommandGroup::Login => handle_login(None).await,
             CommandGroup::Google(google) => google.handle_command().await,
             CommandGroup::Application(application) => {
                 application.handle_command(get_context(self)?).await

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -52,10 +52,10 @@ async fn verify_okta_refresh_token(app: Arc<Mutex<App>>) -> Result<(), WKCliErro
     let mut app_ref = app.lock().await;
     match Config::load_from_default_path() {
         Ok(config) => {
-            let auth_config = config.auth.as_ref();
+            let okta_config = config.auth.okta.as_ref();
 
-            if let Some(auth_config) = auth_config {
-                let token = introspect_token(&config, &auth_config.refresh_token).await?;
+            if let Some(okta_config) = okta_config {
+                let token = introspect_token(&config, &okta_config.refresh_token).await?;
 
                 if token.active {
                     app_ref.state.is_okta_authenticated = Some(true);

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -376,7 +376,7 @@ async fn get_gcloud_logs(
 
     drop(app_ref);
 
-    let gcloud_access_token = auth::google_cloud::get_token_or_login().await;
+    let gcloud_access_token = auth::google_cloud::get_token_or_login(None).await;
 
     if let Some(namespace) = namespace {
         if let Some(version) = version {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -53,10 +53,8 @@ pub static CONFIG_FILE: Lazy<Option<String>> = Lazy::new(|| {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Config {
     pub core: CoreConfig,
-    pub auth: Option<OktaConfig>,
-    pub vault: Option<VaultConfig>,
+    pub auth: AuthConfig,
     pub update_check: Option<UpdateCheck>,
-    pub google_cloud: Option<GoogleCloudConfig>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -96,6 +94,13 @@ pub struct OktaConfig {
     pub refresh_token: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct AuthConfig {
+    pub okta: Option<OktaConfig>,
+    pub vault: Option<VaultConfig>,
+    pub google_cloud: Option<GoogleCloudConfig>,
+}
+
 // ReleaseInfo stores information about a release
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct UpdateCheck {
@@ -113,10 +118,12 @@ impl Default for Config {
                 wukong_api_url: WUKONG_API_URL.to_string(),
                 okta_client_id: OKTA_CLIENT_ID.to_string(),
             },
-            auth: None,
-            vault: None,
+            auth: AuthConfig {
+                okta: None,
+                vault: None,
+                google_cloud: None,
+            },
             update_check: None,
-            google_cloud: None,
         }
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -53,7 +53,7 @@ pub static CONFIG_FILE: Lazy<Option<String>> = Lazy::new(|| {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Config {
     pub core: CoreConfig,
-    pub auth: Option<AuthConfig>,
+    pub auth: Option<OktaConfig>,
     pub vault: Option<VaultConfig>,
     pub update_check: Option<UpdateCheck>,
     pub google_cloud: Option<GoogleCloudConfig>,
@@ -87,7 +87,7 @@ pub struct ConfigWithPath {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
-pub struct AuthConfig {
+pub struct OktaConfig {
     pub account: String,
     pub subject: String,
     pub id_token: String,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -150,7 +150,7 @@ impl Config {
     /// # Errors
     ///
     /// This function may return typical file I/O errors.
-    fn load_from_path(path: &'static str) -> Result<Self, ConfigError> {
+    pub fn load_from_path(path: &'static str) -> Result<Self, ConfigError> {
         let config_file_path = Path::new(path);
 
         let content = std::fs::read_to_string(

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,4 +1,4 @@
-use crate::error::ConfigError;
+use crate::{auth::google_cloud::GoogleCloudConfig, error::ConfigError};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -56,6 +56,7 @@ pub struct Config {
     pub auth: Option<AuthConfig>,
     pub vault: Option<VaultConfig>,
     pub update_check: Option<UpdateCheck>,
+    pub google_cloud: Option<GoogleCloudConfig>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -115,6 +116,7 @@ impl Default for Config {
             auth: None,
             vault: None,
             update_check: None,
+            google_cloud: None,
         }
     }
 }

--- a/cli/src/wukong_client.rs
+++ b/cli/src/wukong_client.rs
@@ -41,7 +41,11 @@ impl From<config::ApiChannel> for wukong_sdk::ApiChannel {
 }
 impl WKClient {
     pub fn for_channel(config: &Config, channel: &ApiChannel) -> Result<Self, WKCliError> {
-        let auth_config = config.auth.as_ref().ok_or(WKCliError::UnAuthenticated)?;
+        let auth_config = config
+            .auth
+            .okta
+            .as_ref()
+            .ok_or(WKCliError::UnAuthenticated)?;
 
         Ok(Self {
             inner: WKSdkClient::new(WKConfig {
@@ -59,7 +63,7 @@ impl WKClient {
             debug!("Access token expired. Refreshing tokens...");
 
             let new_tokens = auth::okta::refresh_tokens(&self.config).await?;
-            self.config.auth = Some(new_tokens.clone().into());
+            self.config.auth.okta = Some(new_tokens.clone().into());
 
             // update config file
             self.config.save_to_default_path()?;

--- a/cli/tests/application.rs
+++ b/cli/tests/application.rs
@@ -68,7 +68,7 @@ application = "valid-application"
 wukong_api_url = "{}"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"

--- a/cli/tests/application.rs
+++ b/cli/tests/application.rs
@@ -112,6 +112,8 @@ fn test_wukong_application_info_should_failed_when_unauthenticated() {
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
 okta_client_id = "valid-okta-client-id"
+
+[auth]
 "#,
         )
         .unwrap();

--- a/cli/tests/application_instances.rs
+++ b/cli/tests/application_instances.rs
@@ -75,7 +75,7 @@ application = "valid-application"
 wukong_api_url = "{}"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -139,7 +139,7 @@ application = "valid-application"
 wukong_api_url = "{}"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"

--- a/cli/tests/config.rs
+++ b/cli/tests/config.rs
@@ -67,6 +67,8 @@ fn test_wukong_config_list_success_without_login() {
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
 okta_client_id = "valid-okta-client-id"
+
+[auth]
     "#,
         )
         .unwrap();

--- a/cli/tests/config.rs
+++ b/cli/tests/config.rs
@@ -29,7 +29,7 @@ application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -113,7 +113,7 @@ application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -153,7 +153,7 @@ application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -193,7 +193,7 @@ application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -223,7 +223,7 @@ application = "new-application"
 wukong_api_url = "https://wukong-api.com"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -250,7 +250,7 @@ application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"

--- a/cli/tests/deployment.rs
+++ b/cli/tests/deployment.rs
@@ -116,6 +116,8 @@ fn test_wukong_deployment_list_should_failed_when_unauthenticated() {
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
 okta_client_id = "valid-okta-client-id"
+
+[auth]
     "#
             .to_string()
             .as_str(),

--- a/cli/tests/deployment.rs
+++ b/cli/tests/deployment.rs
@@ -69,7 +69,7 @@ application = "valid-application"
 wukong_api_url = "{}"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"

--- a/cli/tests/dev_config.rs
+++ b/cli/tests/dev_config.rs
@@ -595,7 +595,7 @@ application = "valid-application"
 wukong_api_url = "{}"
 okta_client_id = "valid-okta-client-id"
 
-[vault]
+[auth.vault]
 api_token = "valid_vault_api_token"
 expiry_time = "2027-06-09T08:51:19.032792+00:00"
 

--- a/cli/tests/dev_config.rs
+++ b/cli/tests/dev_config.rs
@@ -92,11 +92,11 @@ fn mock_user_config(wk_temp: &assert_fs::TempDir, server_url: String) -> ChildPa
                     wukong_api_url = "{}"
                     okta_client_id = "valid-okta-client-id"
 
-                    [vault]
+                    [auth.vault]
                     api_token = "valid_vault_api_token"
                     expiry_time = "2027-06-09T08:51:19.032792+00:00"
 
-                    [auth]
+                    [auth.okta]
                     account = "test@email.com"
                     subject = "subject"
                     id_token = "id_token"
@@ -504,11 +504,11 @@ application = "valid-application"
 wukong_api_url = "{}"
 okta_client_id = "valid-okta-client-id"
 
-[vault]
+[auth.vault]
 api_token = "valid_vault_api_token"
 expiry_time = "2027-06-09T08:51:19.032792+00:00"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -599,7 +599,7 @@ okta_client_id = "valid-okta-client-id"
 api_token = "valid_vault_api_token"
 expiry_time = "2027-06-09T08:51:19.032792+00:00"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"

--- a/cli/tests/pipeline.rs
+++ b/cli/tests/pipeline.rs
@@ -63,7 +63,7 @@ fn test_wukong_pipeline_list_success() {
   wukong_api_url = "{}"
   okta_client_id = "valid-okta-client-id"
 
-  [auth]
+  [auth.okta]
   account = "test@email.com"
   subject = "subject"
   id_token = "id_token"
@@ -265,7 +265,7 @@ application = "valid-application"
 wukong_api_url = "{}"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -344,7 +344,7 @@ application = "valid-application"
 wukong_api_url = "{}"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"

--- a/cli/tests/pipeline.rs
+++ b/cli/tests/pipeline.rs
@@ -107,6 +107,8 @@ fn test_wukong_pipeline_list_should_failed_when_unauthenticated() {
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
 okta_client_id = "valid-okta-client-id"
+
+[auth]
 "#
             .to_string()
             .as_str(),
@@ -143,6 +145,8 @@ fn test_wukong_pipeline_describe_should_failed_when_unauthenticated() {
 application = "valid-application"
 wukong_api_url = "{}"
 okta_client_id = "valid-okta-client-id"
+
+[auth]
 "#,
                 server.base_url(),
             )
@@ -393,6 +397,8 @@ fn test_wukong_pipeline_ci_status_should_failed_when_unauthenticated() {
 application = "valid-application"
 wukong_api_url = "{}"
 okta_client_id = "valid-okta-client-id"
+
+[auth]
 "#,
                 server.base_url(),
             )

--- a/cli/tests/snapshots/config__wukong_config_list_success.snap
+++ b/cli/tests/snapshots/config__wukong_config_list_success.snap
@@ -7,10 +7,12 @@ application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
 okta_client_id = "valid-okta-client-id"
 
-[auth]
+[auth.okta]
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
 access_token = "access_token"
 expiry_time = "2023-02-19T06:55:51.501915+00:00"
 refresh_token = "refresh_token"
+
+

--- a/cli/tests/snapshots/config__wukong_config_list_success_without_login.snap
+++ b/cli/tests/snapshots/config__wukong_config_list_success_without_login.snap
@@ -1,10 +1,12 @@
 ---
-source: tests/config.rs
+source: cli/tests/config.rs
 expression: "std::str::from_utf8(&output.stdout).unwrap()"
 ---
 [core]
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
 okta_client_id = "valid-okta-client-id"
+
+[auth]
 
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

Build the workflow for the wukong init command to satisfy the specifications. Details about the command inputs and outputs can be found [here](https://mindvalley.atlassian.net/wiki/spaces/PXP/pages/762773518/RFC17+-+New+Global+Init+UX).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: https://mindvalley.atlassian.net/browse/PXP-524

## What's Changed

<!-- Explain what is changed in this pull request -->

- [x] Update the Google auth to store in our config file instead of a separate file
- [x] Update all auth logics to refer to new path
- [x] Add google cloud and vault login to `wukong init`
- [x] Updated wukong login logic to use same function on `wukong init` to avoid duplicate codes 

<!-- ### Added -->

<!-- ### Changed -->

<!-- ### Fixed -->
