### PR TITLE
PXP-663: [CLI] Depreciate old error handling

### DIFF
--- a/sdk/src/graphql/changelog.rs
+++ b/sdk/src/graphql/changelog.rs
@@ -84,10 +84,13 @@ mod test {
           "line": 2
         }
       ],
-      "message": "application_not_found",
+      "message": "Application not found in application config",
       "path": [
         "changelogs"
-      ]
+      ],
+      "extensions": {
+        "code": "application_not_found"
+      }
     }
   ]
 }"#;
@@ -132,10 +135,13 @@ mod test {
           "line": 2
         }
       ],
-      "message": "unable_to_determine_changelog",
+      "message": "Unable to determine changelog",
       "path": [
         "changelogs"
-      ]
+      ],
+      "extensions": {
+        "code": "changelog_unable_to_determine"
+      }
     }
   ]
 }"#;
@@ -184,10 +190,13 @@ mod test {
           "line": 2
         }
       ],
-      "message": "comparing_same_build",
+      "message": "Changelog has same commit",
       "path": [
         "changelogs"
-      ]
+      ],
+      "extensions": {
+        "code": "changelog_same_commit"
+      }
     }
   ]
 }"#;

--- a/sdk/src/graphql/deployment.rs
+++ b/sdk/src/graphql/deployment.rs
@@ -116,10 +116,13 @@ mod test {
           "line": 2
         }
       ],
-      "message": "application_not_found",
+      "message": "Application not found in application config",
       "path": [
         "cdPipelines"
-      ]
+      ],
+      "extensions": {
+        "code": "application_not_found"
+      }
     }
   ]
 }"#;
@@ -251,10 +254,13 @@ mod test {
           "line": 2
         }
       ],
-      "message": "deploy_for_this_build_is_currently_running",
+      "message": "Deployment in progress",
       "path": [
         "executeCdPipeline"
-      ]
+      ],
+      "extensions": {
+        "code": "pipeline_deployment_in_progress"
+      }
     }
   ]
 }"#;

--- a/sdk/src/graphql/deployment_github.rs
+++ b/sdk/src/graphql/deployment_github.rs
@@ -113,7 +113,7 @@ mod test {
       ],
       "extensions": {
         "code": "github_workflow_not_found"
-      },
+      }
     }
   ]
 }"#;
@@ -139,7 +139,7 @@ mod test {
                 message: _message,
                 code,
             }) => {
-                assert_eq!(code, "Unable to get workflow");
+                assert_eq!(code, "github_workflow_not_found");
             }
             _ => panic!("it should be returning APIError::UnableToGetPipelines"),
         };

--- a/sdk/src/graphql/deployment_github.rs
+++ b/sdk/src/graphql/deployment_github.rs
@@ -100,9 +100,6 @@ mod test {
   },
   "errors": [
     {
-      "extensions": {
-        "code": "github_workflow_not_found"
-      },
       "locations": [
         {
           "column": 5,
@@ -113,7 +110,10 @@ mod test {
       "path": [
         "cdPipeline",
         "githubBuilds"
-      ]
+      ],
+      "extensions": {
+        "code": "github_workflow_not_found"
+      },
     }
   ]
 }"#;

--- a/sdk/src/graphql/kubernetes.rs
+++ b/sdk/src/graphql/kubernetes.rs
@@ -119,7 +119,10 @@ mod test {
       "message": "Unauthorized",
       "path": [
         "kubernetesPods"
-      ]
+      ],
+      "extensions": {
+        "code": "unauthorized"
+      }
     }
   ]
 }"#;

--- a/sdk/src/graphql/mod.rs
+++ b/sdk/src/graphql/mod.rs
@@ -743,6 +743,7 @@ impl ErrorHandler for CanaryErrorHandler {
 }
 
 fn setup_error_handler(_channel: &ApiChannel) -> Box<dyn ErrorHandler> {
+    // TODO: Cleanup outdated error handler:
     Box::new(CanaryErrorHandler)
 }
 

--- a/sdk/src/graphql/mod.rs
+++ b/sdk/src/graphql/mod.rs
@@ -742,11 +742,8 @@ impl ErrorHandler for CanaryErrorHandler {
     }
 }
 
-fn setup_error_handler(channel: &ApiChannel) -> Box<dyn ErrorHandler> {
-    match channel {
-        ApiChannel::Canary => Box::new(CanaryErrorHandler),
-        ApiChannel::Stable => Box::new(DefaultErrorHandler),
-    }
+fn setup_error_handler(_channel: &ApiChannel) -> Box<dyn ErrorHandler> {
+    Box::new(CanaryErrorHandler)
 }
 
 #[cfg(test)]

--- a/sdk/src/graphql/mod.rs
+++ b/sdk/src/graphql/mod.rs
@@ -768,10 +768,13 @@ mod test {
               "line": 2
             }
           ],
-          "message": "application_not_found",
+          "message": "Application not found",
           "path": [
             "ciStatus"
-          ]
+          ],
+          "extensions": {
+            "code": "application_not_found"
+          }
         });
 
         let deserialized_error: Error = serde_json::from_value(err).unwrap();

--- a/sdk/src/graphql/pipeline.rs
+++ b/sdk/src/graphql/pipeline.rs
@@ -135,7 +135,7 @@ mod test {
         let error = response.unwrap_err();
 
         match &error {
-            WKError::APIError(APIError::UnableToGetPipeline) => {},
+            WKError::APIError(APIError::UnableToGetPipeline) => {}
             _ => panic!("it should be returning APIError::UnableToGetPipeline"),
         };
 

--- a/sdk/src/graphql/pipeline.rs
+++ b/sdk/src/graphql/pipeline.rs
@@ -109,10 +109,13 @@ mod test {
           "line": 2
         }
       ],
-      "message": "unable_to_get_pipelines",
+      "message": "Pipeline not found",
       "path": [
         "pipelines"
-      ]
+      ],
+      "extensions": {
+        "code": "pipeline_not_found"
+      }
     }
   ]
 }"#;
@@ -201,10 +204,13 @@ mod test {
           "line": 2
         }
       ],
-      "message": "unable_to_get_pipeline",
+      "message": "Pipeline not found",
       "path": [
-        "pipeline"
-      ]
+        "pipelines"
+      ],
+      "extensions": {
+        "code": "pipeline_not_found"
+      }
     }
   ]
 }"#;
@@ -315,10 +321,13 @@ mod test {
           "line": 2
         }
       ],
-      "message": "unable_to_get_pipeline",
+      "message": "Pipeline not found",
       "path": [
-        "multiBranchPipeline"
-      ]
+        "pipelines"
+      ],
+      "extensions": {
+        "code": "pipeline_not_found"
+      }
     }
   ]
 }"#;
@@ -415,10 +424,13 @@ mod test {
           "line": 2
         }
       ],
-      "message": "application_not_found",
+      "message": "Application not found in application config",
       "path": [
         "ciStatus"
-      ]
+      ],
+      "extensions": {
+        "code": "application_not_found"
+      }
     }
   ]
 }"#;
@@ -465,10 +477,13 @@ mod test {
           "line": 2
         }
       ],
-      "message": "no_builds_associated_with_this_branch",
+      "message": "Jenkins build not found on this branch",
       "path": [
         "ciStatus"
-      ]
+      ],
+      "extensions": {
+        "code": "jenkins_build_not_found"
+      }
     }
   ]
 }"#;

--- a/sdk/src/graphql/pipeline.rs
+++ b/sdk/src/graphql/pipeline.rs
@@ -133,12 +133,13 @@ mod test {
         assert!(response.is_err());
 
         let error = response.unwrap_err();
+
         match &error {
-            WKError::APIError(APIError::UnableToGetPipelines) => {}
-            _ => panic!("it should be returning APIError::UnableToGetPipelines"),
+            WKError::APIError(APIError::UnableToGetPipeline) => {},
+            _ => panic!("it should be returning APIError::UnableToGetPipeline"),
         };
 
-        assert_eq!(format!("{error}"), "Unable to get pipelines.");
+        assert_eq!(format!("{error}"), "Unable to get pipeline.");
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary
This pull request addresses an issue where the v1 error handling format was accidently replaced with a new one. To ensure consistency across different API environments, a quick switch has been implemented in the CLI. The primary objective is to align the error code format uniformly, irrespective of the API environment.

Additionally, please note that a subsequent pull request will be submitted to clean up the deprecated or old error handling code, maintaining codebase hygiene.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: https://mindvalley.atlassian.net/browse/PXP-663

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

### Changed

- [x] Replaced the error match function to enforce the usage of the new error code format only.

### Next Steps 
A follow-up pull request is planned to conduct a thorough cleanup of the outdated error handling code

