### PR TITLE
PXP-664 refactor: replace global init with inquire library

### DIFF
--- a/cli/src/auth/google_cloud.rs
+++ b/cli/src/auth/google_cloud.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::{config::Config, loader::new_spinner};
 use serde::{Deserialize, Serialize};
 use std::{future::Future, pin::Pin};
 use time::{format_description, OffsetDateTime};
@@ -22,7 +22,7 @@ struct JSONToken {
 async fn browser_user_url(url: &str, need_code: bool) -> Result<String, String> {
     let url = format!("{}&prompt=consent", url);
     if webbrowser::open(&url).is_ok() {
-        println!("Your browser has been opened to visit:\n\n\t{url}\n");
+        println!("Opening browser to:\n\n\t{url}\n");
         Ok(String::new())
     } else {
         let def_delegate = DefaultInstalledFlowDelegate;
@@ -115,6 +115,8 @@ impl TokenStorage for ConfigTokenStore {
 }
 
 pub async fn get_token_or_login(config: Option<Config>) -> String {
+    let loader = new_spinner().with_message("Logging in to Google Cloud ...");
+
     let secret = ApplicationSecret {
         client_id: GOOGLE_CLIENT_ID.to_string(),
         client_secret: GOOGLE_CLIENT_SECRET.to_string(),
@@ -151,6 +153,8 @@ pub async fn get_token_or_login(config: Option<Config>) -> String {
     .build()
     .await
     .unwrap();
+
+    loader.finish_and_clear();
 
     authenticator
         .token(&["https://www.googleapis.com/auth/logging.read"])

--- a/cli/src/auth/okta.rs
+++ b/cli/src/auth/okta.rs
@@ -114,7 +114,7 @@ pub async fn login(config: &Config) -> Result<OktaAuth, WKCliError> {
         .set_pkce_challenge(pkce_challenge)
         .url();
 
-    println!("Opening browser to: {authorize_url}\n");
+    println!("Opening browser to:\n\n\t{authorize_url}\n");
     let spinner = new_spinner().with_message("Waiting for login");
 
     webbrowser::open(authorize_url.as_str()).unwrap();
@@ -157,7 +157,6 @@ pub async fn login(config: &Config) -> Result<OktaAuth, WKCliError> {
         // state = CsrfToken::new(value.into_owned());
     }
 
-
     spinner.finish_and_clear();
 
     let message = "You are now authenticated with the wukong CLI! The authentication flow has completed successfully. You can close this window and go back to your terminal :)";
@@ -167,7 +166,6 @@ pub async fn login(config: &Config) -> Result<OktaAuth, WKCliError> {
         message
     );
     stream.write_all(response.as_bytes()).unwrap();
-
 
     // Exchange the code with a token.
     let token_response = client

--- a/cli/src/commands/config/get.rs
+++ b/cli/src/commands/config/get.rs
@@ -4,10 +4,18 @@ use super::ConfigName;
 
 pub fn handle_get(config_name: &ConfigName) -> Result<bool, WKCliError> {
     let config = CliConfig::load_from_default_path()?;
+    println!("{:?}", config_name);
     match config_name {
         ConfigName::Application => println!("{}", config.core.application),
         ConfigName::WukongApiUrl => println!("{}", config.core.wukong_api_url),
-        ConfigName::OktaClientId => println!("{}", config.core.okta_client_id),
+        ConfigName::OktaClientId => println!(
+            "{}",
+            if let Some(okta) = config.auth.okta {
+                okta.client_id
+            } else {
+                "Okta client id not set. Please use `wukong login`".to_string()
+            }
+        ),
     };
     Ok(true)
 }

--- a/cli/src/commands/config/set.rs
+++ b/cli/src/commands/config/set.rs
@@ -15,11 +15,16 @@ pub fn handle_set(config_name: &ConfigName, config_value: &str) -> Result<bool, 
             config.save_to_default_path()?;
             println!("Updated property [core/wukong_api_url].");
         }
-        ConfigName::OktaClientId => {
-            config.core.okta_client_id = config_value.trim().to_string();
-            config.save_to_default_path()?;
-            println!("Updated property [core/okta_client_id].");
-        }
+        ConfigName::OktaClientId => match &mut config.auth.okta {
+            Some(okta) => {
+                okta.client_id = config_value.trim().to_string();
+                config.save_to_default_path()?;
+                println!("Updated property [core/okta_client_id].");
+            }
+            None => {
+                eprintln!("Okta client id not set. Please use `wukong login`");
+            }
+        },
     };
     Ok(true)
 }

--- a/cli/src/commands/google/login.rs
+++ b/cli/src/commands/google/login.rs
@@ -1,13 +1,7 @@
-use crate::{auth, config::Config, error::WKCliError, loader::new_spinner};
+use crate::{auth, config::Config, error::WKCliError};
 
 pub async fn handle_login(config: Option<Config>) -> Result<bool, WKCliError> {
-    let loader = new_spinner();
-    loader.set_message("Logging in to Google Cloud ...");
-
     auth::google_cloud::get_token_or_login(config).await;
-    loader.finish_with_message(
-        "Successfully logged in to Google Cloud. You can now use Wukong to manage your Google Cloud resources.\n",
-    );
-
+    println!("You are logged into Google Cloud. You can now use Wukong to manage your Google Cloud resources");
     Ok(true)
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -2,15 +2,14 @@ use crate::{
     auth::vault,
     commands::google,
     commands::login,
-    config::{ApiChannel, Config},
+    config::{get_inquire_render_config, ApiChannel, Config},
     error::{ConfigError, WKCliError},
     loader::new_spinner,
     output::colored_println,
     wukong_client::WKClient,
 };
-use dialoguer::{theme::ColorfulTheme, Confirm, Select};
+use crossterm::style::Stylize;
 use once_cell::sync::Lazy;
-use owo_colors::OwoColorize;
 
 pub static TMP_CONFIG_FILE: Lazy<Option<String>> = Lazy::new(|| {
     return dirs::home_dir().map(|mut path| {
@@ -41,32 +40,35 @@ pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
 
     colored_println!(
         r#"
-Your Wukong CLI is configured and ready to use!
+{}
 
-* Commands that require authentication will use {} by default
-* Commands will reference application {} by default
-Run `wukong config help` to learn how to change individual settings
+{} Commands that require authentication will use {} by default
+{} Commands will reference application {} by default
+{} Run `wukong config help` to learn how to change individual settings
 
-Some things to try next:
-
-* Run `wukong --help` to see the wukong command groups you can interact with. And run `wukong COMMAND help` to get help on any wukong command.
+{}
+{} Run `wukong --help` to see the wukong command groups you can interact with. And run `wukong COMMAND help` to get help on any wukong command.
                              "#,
-        config.auth.okta.as_ref().unwrap().account,
-        config.core.application
+        "Your Wukong CLI is configured and ready to use!".bold(),
+        "▸".green(),
+        config.auth.okta.expect("Okta account not found").account.dark_cyan(),
+        "▸".green(),
+        config.core.application.dark_cyan(),
+        "▸".green(),
+        "Some things to try next:".bold(),
+        "▸".green(),
     );
 
     Ok(true)
 }
 
 async fn handle_vault_auth(mut config: Config) -> Result<Config, WKCliError> {
-    let agree_to_authenticate = Confirm::with_theme(&ColorfulTheme::default())
-        .with_prompt(format!(
-            "{} {}",
-            "(Optional)".bright_black(),
-            "Do you want to authenticate against Bunker? You may do it later when neccessary"
-        ))
-        .default(false)
-        .interact()?;
+    let agree_to_authenticate =
+        inquire::Confirm::new("Do you want to authenticate against Bunker?")
+            .with_render_config(get_inquire_render_config())
+            .with_help_message("You may able to login later when neccessary.")
+            .with_default(false)
+            .prompt()?;
 
     if agree_to_authenticate {
         vault::get_token_or_login(&mut config).await?;
@@ -76,14 +78,12 @@ async fn handle_vault_auth(mut config: Config) -> Result<Config, WKCliError> {
 }
 
 async fn handle_gcloud_auth(mut config: Config) -> Result<Config, WKCliError> {
-    let agree_to_authenticate = Confirm::with_theme(&ColorfulTheme::default())
-        .with_prompt(format!(
-            "{} {}",
-            "(Optional)".bright_black(),
-            "Do you want to authenticate against Google Cloud? You may do it later when neccessary"
-        ))
-        .default(false)
-        .interact()?;
+    let agree_to_authenticate =
+        inquire::Confirm::new("Do you want to authenticate against Google Cloud?")
+            .with_render_config(get_inquire_render_config())
+            .with_help_message("You may able to login later when neccessary.")
+            .with_default(false)
+            .prompt()?;
 
     if agree_to_authenticate {
         // Use temporary file to achieve atomic write for gcloud:
@@ -127,18 +127,13 @@ async fn handle_application(mut config: Config, channel: ApiChannel) -> Result<C
 
     fetch_loader.finish_and_clear();
 
-    let application_selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Please select the application")
-        .default(0)
-        .items(&applications_data[..])
-        .interact()?;
+    let selected_application =
+        inquire::Select::new("Please select the application", applications_data)
+            .with_render_config(get_inquire_render_config())
+            .with_page_size(15)
+            .prompt()?;
 
-    colored_println!(
-        "Your current application has been set to: {}.",
-        &applications_data[application_selection]
-    );
-
-    config.core.application = applications_data[application_selection].clone();
+    config.core.application = selected_application;
 
     Ok(config)
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -2,11 +2,9 @@ use crate::{
     auth::vault,
     commands::google,
     commands::login,
-    config::{get_inquire_render_config, ApiChannel, Config},
+    config::{get_inquire_render_config, Config},
     error::{ConfigError, WKCliError},
-    loader::new_spinner,
     output::colored_println,
-    wukong_client::WKClient,
 };
 use crossterm::style::Stylize;
 use once_cell::sync::Lazy;
@@ -18,7 +16,7 @@ pub static TMP_CONFIG_FILE: Lazy<Option<String>> = Lazy::new(|| {
     });
 });
 
-pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
+pub async fn handle_init() -> Result<bool, WKCliError> {
     println!("Welcome! This command will take you through the configuration of Wukong.\n");
     let mut config = match Config::load_from_default_path() {
         Ok(config) => config,
@@ -30,7 +28,6 @@ pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
     };
 
     config = login::new_login_or_refresh_token(config).await?;
-    config = handle_application(config, channel).await?;
     config = handle_gcloud_auth(config).await?;
     config = handle_vault_auth(config).await?;
 
@@ -43,7 +40,6 @@ pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
 {}
 
 {} Commands that require authentication will use {} by default
-{} Commands will reference application {} by default
 {} Run `wukong config help` to learn how to change individual settings
 
 {}
@@ -57,8 +53,6 @@ pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
             .expect("Okta account not found")
             .account
             .dark_cyan(),
-        "▸".green(),
-        config.core.application.dark_cyan(),
         "▸".green(),
         "Some things to try next:".bold(),
         "▸".green(),
@@ -112,33 +106,6 @@ async fn handle_gcloud_auth(mut config: Config) -> Result<Config, WKCliError> {
 
         return Ok(config);
     }
-
-    Ok(config)
-}
-
-async fn handle_application(mut config: Config, channel: ApiChannel) -> Result<Config, WKCliError> {
-    let fetch_loader = new_spinner();
-    fetch_loader.set_message("Fetching application list...");
-
-    let mut wk_client = WKClient::for_channel(&config, &channel)?;
-
-    let applications_data: Vec<String> = wk_client
-        .fetch_applications()
-        .await?
-        .applications
-        .iter()
-        .map(|app| app.name.clone())
-        .collect();
-
-    fetch_loader.finish_and_clear();
-
-    let selected_application =
-        inquire::Select::new("Please select the application", applications_data)
-            .with_render_config(get_inquire_render_config())
-            .with_page_size(15)
-            .prompt()?;
-
-    config.core.application = selected_application;
 
     Ok(config)
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -71,7 +71,7 @@ async fn handle_vault_auth(mut config: Config) -> Result<Config, WKCliError> {
     let agree_to_authenticate =
         inquire::Confirm::new("Do you want to authenticate against Bunker?")
             .with_render_config(get_inquire_render_config())
-            .with_help_message("You may able to login later when neccessary.")
+            .with_help_message("You may able to login later when neccessary")
             .with_default(false)
             .prompt()?;
 
@@ -86,7 +86,7 @@ async fn handle_gcloud_auth(mut config: Config) -> Result<Config, WKCliError> {
     let agree_to_authenticate =
         inquire::Confirm::new("Do you want to authenticate against Google Cloud?")
             .with_render_config(get_inquire_render_config())
-            .with_help_message("You may able to login later when neccessary.")
+            .with_help_message("You may able to login later when neccessary")
             .with_default(false)
             .prompt()?;
 

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -51,7 +51,12 @@ pub async fn handle_init(channel: ApiChannel) -> Result<bool, WKCliError> {
                              "#,
         "Your Wukong CLI is configured and ready to use!".bold(),
         "▸".green(),
-        config.auth.okta.expect("Okta account not found").account.dark_cyan(),
+        config
+            .auth
+            .okta
+            .expect("Okta account not found")
+            .account
+            .dark_cyan(),
         "▸".green(),
         config.core.application.dark_cyan(),
         "▸".green(),

--- a/cli/src/commands/login.rs
+++ b/cli/src/commands/login.rs
@@ -75,7 +75,7 @@ pub async fn new_login_or_refresh_token(config: Config) -> Result<Config, WKCliE
 }
 
 async fn login_and_create_config(mut config: Config) -> Result<Config, WKCliError> {
-    let auth_info = auth::okta::login(&config).await?;
+    let auth_info = auth::okta::login().await?;
     let acc = auth_info.account.clone();
 
     config.auth.okta = Some(auth_info.into());

--- a/cli/src/commands/login.rs
+++ b/cli/src/commands/login.rs
@@ -5,6 +5,7 @@ use crate::{
     loader::new_spinner,
     output::colored_println,
 };
+use crossterm::style::Stylize;
 use log::debug;
 
 pub async fn handle_login() -> Result<bool, WKCliError> {
@@ -17,20 +18,20 @@ pub async fn handle_login() -> Result<bool, WKCliError> {
 }
 
 pub async fn new_login_or_refresh_token(config: Config) -> Result<Config, WKCliError> {
-    let mut login_selections = vec!["Log in with a new account"];
+    let mut login_selections = vec!["Login with a new account"];
     if let Some(ref okta_config) = config.auth.okta {
         login_selections.splice(..0, vec![okta_config.account.as_str()]);
     };
 
     let selected_account = inquire::Select::new(
-        "Choose the account you would like to use to perform operations for this configuration:",
+        "Choose the account you would like to continue with",
         login_selections,
     )
     .with_render_config(get_inquire_render_config())
     .prompt()?;
 
     // "Log in with a new account" is selected
-    let new_config = if selected_account == "Log in with a new account" {
+    let new_config = if selected_account == "Login with a new account" {
         login_and_create_config(config).await?
     } else {
         // check access token expiry
@@ -46,7 +47,7 @@ pub async fn new_login_or_refresh_token(config: Config) -> Result<Config, WKCliE
                     current_config.auth.okta = Some(new_tokens.into());
 
                     refresh_token_loader.finish_and_clear();
-                    colored_println!("You are logged in as: {}.\n", selected_account,);
+                    colored_println!("You are logged in as: {}", selected_account.dark_cyan());
 
                     current_config
                 }
@@ -64,7 +65,7 @@ pub async fn new_login_or_refresh_token(config: Config) -> Result<Config, WKCliE
 
             current_config = updated_config;
         } else {
-            colored_println!("You are logged in as: {}.\n", selected_account);
+            colored_println!("You are logged in as: {}", selected_account.dark_cyan());
         }
 
         current_config
@@ -79,7 +80,7 @@ async fn login_and_create_config(mut config: Config) -> Result<Config, WKCliErro
 
     config.auth.okta = Some(auth_info.into());
 
-    colored_println!("You are logged in as: {acc}.\n");
+    colored_println!("You are logged in as: {}", acc.dark_cyan());
 
     Ok(config)
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -118,7 +118,7 @@ impl ClapApp {
         debug!("API channel: {:?}", channel);
 
         let command = match &self.command_group {
-            CommandGroup::Init => handle_init(channel).await,
+            CommandGroup::Init => handle_init().await,
             CommandGroup::Completion { shell } => handle_completion(*shell),
             CommandGroup::Login => handle_login().await,
             CommandGroup::Google(google) => google.handle_command().await,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -13,13 +13,9 @@ use std::{
 
 #[cfg(not(feature = "prod"))]
 static WUKONG_API_URL: &str = "http://localhost:4000/api";
-#[cfg(not(feature = "prod"))]
-static OKTA_CLIENT_ID: &str = "0oakfxaegyAV5JDD5357";
 
 #[cfg(feature = "prod")]
 static WUKONG_API_URL: &str = "https://wukong-api-proxy.mindvalley.dev/api";
-#[cfg(feature = "prod")]
-static OKTA_CLIENT_ID: &str = "0oakfxaegyAV5JDD5357";
 
 /// The default path to the CLI configuration file.
 ///
@@ -110,7 +106,6 @@ pub struct CoreConfig {
     /// The current application name
     pub application: String,
     pub wukong_api_url: String,
-    pub okta_client_id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -121,6 +116,7 @@ pub struct VaultConfig {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct OktaConfig {
+    pub client_id: String,
     pub account: String,
     pub subject: String,
     pub id_token: String,
@@ -150,7 +146,6 @@ impl Default for Config {
             core: CoreConfig {
                 application: "".to_string(),
                 wukong_api_url: WUKONG_API_URL.to_string(),
-                okta_client_id: OKTA_CLIENT_ID.to_string(),
             },
             auth: AuthConfig {
                 okta: None,

--- a/cli/src/loader.rs
+++ b/cli/src/loader.rs
@@ -1,9 +1,16 @@
 use indicatif::{ProgressBar, ProgressStyle};
 
+pub const TICK_STRING: &str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ ";
+
 pub fn new_spinner() -> ProgressBar {
     let steps = 1_000_000;
-    let progress_bar = ProgressBar::new(steps);
-    progress_bar.set_style(ProgressStyle::default_spinner());
+
+    let progress_bar = ProgressBar::new(steps).with_style(
+        indicatif::ProgressStyle::default_spinner()
+            .tick_chars(TICK_STRING)
+            .template("{spinner:.green} {msg}")
+            .expect("Invalid template"),
+    );
 
     progress_bar.enable_steady_tick(std::time::Duration::from_millis(80));
     progress_bar

--- a/cli/tests/application.rs
+++ b/cli/tests/application.rs
@@ -66,9 +66,9 @@ fn test_wukong_application_info_success() {
 [core]
 application = "valid-application"
 wukong_api_url = "{}"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -111,7 +111,6 @@ fn test_wukong_application_info_should_failed_when_unauthenticated() {
 [core]
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
-okta_client_id = "valid-okta-client-id"
 
 [auth]
 "#,

--- a/cli/tests/application_instances.rs
+++ b/cli/tests/application_instances.rs
@@ -73,9 +73,9 @@ fn test_wukong_application_instances_list_success() {
 [core]
 application = "valid-application"
 wukong_api_url = "{}"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -137,9 +137,9 @@ fn test_wukong_application_instances_list_failed_if_not_authorized() {
 [core]
 application = "valid-application"
 wukong_api_url = "{}"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"

--- a/cli/tests/config.rs
+++ b/cli/tests/config.rs
@@ -27,9 +27,9 @@ fn test_wukong_config_list_success() {
 [core]
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -66,7 +66,6 @@ fn test_wukong_config_list_success_without_login() {
 [core]
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
-okta_client_id = "valid-okta-client-id"
 
 [auth]
     "#,
@@ -113,9 +112,9 @@ fn test_wukong_config_get_success() {
 [core]
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -153,9 +152,9 @@ fn test_wukong_config_get_should_failed_with_non_supported_field() {
 [core]
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -193,9 +192,9 @@ fn test_wukong_config_set_success_with_supported_field() {
 [core]
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -223,9 +222,9 @@ refresh_token = "refresh_token"
         r#"[core]
 application = "new-application"
 wukong_api_url = "https://wukong-api.com"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -250,9 +249,9 @@ fn test_wukong_config_set_should_failed_with_non_supported_field() {
 [core]
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"

--- a/cli/tests/deployment.rs
+++ b/cli/tests/deployment.rs
@@ -67,9 +67,9 @@ fn test_wukong_deployment_list_success() {
 [core]
 application = "valid-application"
 wukong_api_url = "{}"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -115,7 +115,6 @@ fn test_wukong_deployment_list_should_failed_when_unauthenticated() {
 [core]
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
-okta_client_id = "valid-okta-client-id"
 
 [auth]
     "#

--- a/cli/tests/dev_config.rs
+++ b/cli/tests/dev_config.rs
@@ -90,13 +90,13 @@ fn mock_user_config(wk_temp: &assert_fs::TempDir, server_url: String) -> ChildPa
                     [core]
                     application = "valid-application"
                     wukong_api_url = "{}"
-                    okta_client_id = "valid-okta-client-id"
 
                     [auth.vault]
                     api_token = "valid_vault_api_token"
                     expiry_time = "2027-06-09T08:51:19.032792+00:00"
 
                     [auth.okta]
+                    client_id = "valid-okta-client-id"
                     account = "test@email.com"
                     subject = "subject"
                     id_token = "id_token"
@@ -502,13 +502,13 @@ fn test_wukong_dev_config_pull_for_wukong_toml_success() {
 [core]
 application = "valid-application"
 wukong_api_url = "{}"
-okta_client_id = "valid-okta-client-id"
 
 [auth.vault]
 api_token = "valid_vault_api_token"
 expiry_time = "2027-06-09T08:51:19.032792+00:00"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -593,13 +593,13 @@ fn test_wukong_dev_config_pull_for_dev_exs_success() {
 [core]
 application = "valid-application"
 wukong_api_url = "{}"
-okta_client_id = "valid-okta-client-id"
 
 [auth.vault]
 api_token = "valid_vault_api_token"
 expiry_time = "2027-06-09T08:51:19.032792+00:00"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"

--- a/cli/tests/pipeline.rs
+++ b/cli/tests/pipeline.rs
@@ -61,9 +61,9 @@ fn test_wukong_pipeline_list_success() {
   [core]
   application = "valid-application"
   wukong_api_url = "{}"
-  okta_client_id = "valid-okta-client-id"
 
   [auth.okta]
+  client_id = "valid-okta-client-id"
   account = "test@email.com"
   subject = "subject"
   id_token = "id_token"
@@ -106,7 +106,6 @@ fn test_wukong_pipeline_list_should_failed_when_unauthenticated() {
 [core]
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
-okta_client_id = "valid-okta-client-id"
 
 [auth]
 "#
@@ -144,7 +143,6 @@ fn test_wukong_pipeline_describe_should_failed_when_unauthenticated() {
 [core]
 application = "valid-application"
 wukong_api_url = "{}"
-okta_client_id = "valid-okta-client-id"
 
 [auth]
 "#,
@@ -267,9 +265,9 @@ fn test_wukong_pipeline_describe_success() {
 [core]
 application = "valid-application"
 wukong_api_url = "{}"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -346,9 +344,9 @@ fn test_wukong_pipeline_ci_status_success() {
 [core]
 application = "valid-application"
 wukong_api_url = "{}"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"
@@ -396,7 +394,6 @@ fn test_wukong_pipeline_ci_status_should_failed_when_unauthenticated() {
 [core]
 application = "valid-application"
 wukong_api_url = "{}"
-okta_client_id = "valid-okta-client-id"
 
 [auth]
 "#,

--- a/cli/tests/snapshots/config__wukong_config_get_success.snap
+++ b/cli/tests/snapshots/config__wukong_config_get_success.snap
@@ -1,6 +1,7 @@
 ---
-source: tests/config.rs
+source: cli/tests/config.rs
 expression: "std::str::from_utf8(&output.stdout).unwrap()"
 ---
+Application
 valid-application
 

--- a/cli/tests/snapshots/config__wukong_config_list_success.snap
+++ b/cli/tests/snapshots/config__wukong_config_list_success.snap
@@ -5,9 +5,9 @@ expression: "std::str::from_utf8(&output.stdout).unwrap()"
 [core]
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
-okta_client_id = "valid-okta-client-id"
 
 [auth.okta]
+client_id = "valid-okta-client-id"
 account = "test@email.com"
 subject = "subject"
 id_token = "id_token"

--- a/cli/tests/snapshots/config__wukong_config_list_success_without_login.snap
+++ b/cli/tests/snapshots/config__wukong_config_list_success_without_login.snap
@@ -5,7 +5,6 @@ expression: "std::str::from_utf8(&output.stdout).unwrap()"
 [core]
 application = "valid-application"
 wukong_api_url = "https://wukong-api.com"
-okta_client_id = "valid-okta-client-id"
 
 [auth]
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary
We are already using the new input library, inquire, for the per-application initialization flow. It would be beneficial to do the same thing with the global initialization flow as well.


https://github.com/mindvalley/wukong-cli/assets/25294487/4dcf6df2-c19e-4c65-aba4-c47a39fa428e



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: https://mindvalley.atlassian.net/browse/PXP-664

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

 ### Changed 

- [x] Change the text of browser opening to make it shorter from `Your browser has been opened to visit` to `Opening browser to`
- [x] Updated loader icon to green
- [x] Updated init success message
- [x] Replace the `dialoguer`  with `inquire` 
- [x] Some color changes to meet the new styling
- [x] Removed application selector from init flow
- [x] Move the okta client id to okta group
- [x] Updated set & get config command to match new structure for okta client id

### Fixed 
- [x] Fix an issue where `Logging in to Google Cloud` does not clear after logged in

