### PR TITLE
Fix: Apply new clippy changes for for rust version (1.26.0)

### DIFF
--- a/cli/src/commands/application/logs.rs
+++ b/cli/src/commands/application/logs.rs
@@ -24,8 +24,8 @@ pub async fn handle_logs(
     since: &Option<String>,
     until: &Option<String>,
     limit: &i32,
-    include: &Vec<String>,
-    exclude: &Vec<String>,
+    include: &[String],
+    exclude: &[String],
     url_mode: &bool,
 ) -> Result<bool, WKCliError> {
     let auth_loader = new_spinner();


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary
With the new clippy version the lint checks for function arguments of type &String, &Vec, &PathBuf, and Cow<_>. It will also suggest you replace .clone() calls with the appropriate .to_owned()/to_string() calls.

More info: https://rust-lang.github.io/rust-clippy/master/index.html#/ptr_arg

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->


## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

### Changed

- [x]  Updated `&Vec<String>` to `&[String]`

<!-- ### Fixed -->
