### PR TITLE
PXP-672: [CLI] Include .yaml file types in application init workflow list

### DIFF
--- a/cli/src/commands/application/init.rs
+++ b/cli/src/commands/application/init.rs
@@ -270,7 +270,7 @@ fn get_workflows_from_current_dir() -> Result<Vec<String>, WKCliError> {
             && workflow
                 .path()
                 .extension()
-                .map_or(false, |ext| ext == "yml")
+                .map_or(false, |ext| ext == "yml" || ext == "yaml")
         {
             let workflow_content = fs::read_to_string(workflow.path())?;
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

This PR addresses an issue in the application initialization process where the CLI was not displaying all available GitHub Actions workflows during step #2. The root cause of the problem was identified as the exclusion of `.yaml` files when checking for workflows in the `.github/workflows` directory.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-672](https://mindvalley.atlassian.net/browse/PXP-672)

## What's Changed
<img width="1207" alt="Screenshot 2024-03-04 at 3 27 09 PM" src="https://github.com/mindvalley/wukong-cli/assets/25294487/fdab4e04-ea59-4a52-a0b4-c8a1f5c0f440">



<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

### Fixed

- [x] Include `.yaml` file in workflow filter


[PXP-672]: https://mindvalley.atlassian.net/browse/PXP-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ