### PR TITLE
PXP-675: [CLI] Make canary flag enabled by default

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -50,7 +50,7 @@ pub struct ClapApp {
     pub report: bool,
 
     /// Use the Canary channel API
-    #[arg(long, global = true)]
+    #[arg(long, global = true, default_value_t = true)]
     canary: bool,
 }
 
@@ -110,9 +110,12 @@ pub enum CommandGroup {
 impl ClapApp {
     pub async fn execute(&self) -> Result<bool, WKCliError> {
         debug!("current cli version: {}", crate_version!());
+        let channel = if self.canary {
+            ApiChannel::Canary
+        } else {
+            ApiChannel::Stable
+        };
 
-        // starting from v2.1.0, the CLI will use the Canary channel API by default.
-        let channel = ApiChannel::Canary;
         debug!("API channel: {:?}", channel);
 
         let command = match &self.command_group {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -110,11 +110,9 @@ pub enum CommandGroup {
 impl ClapApp {
     pub async fn execute(&self) -> Result<bool, WKCliError> {
         debug!("current cli version: {}", crate_version!());
-        let channel = if self.canary {
-            ApiChannel::Canary
-        } else {
-            ApiChannel::Stable
-        };
+
+        // starting from v2.1.0, the CLI will use the Canary channel API by default.
+        let channel = ApiChannel::Canary;
         debug!("API channel: {:?}", channel);
 
         let command = match &self.command_group {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->


<img width="301" alt="Screenshot 2024-03-06 at 3 57 11 PM" src="https://github.com/mindvalley/wukong-cli/assets/7545747/0a19d1a1-ec38-43ec-a047-a0d38f53fafe">


Ticket: [PXP-675](https://mindvalley.atlassian.net/browse/PXP-675)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

### Changed
- [x] The `--canary` flag is now `true` by default starting from v2.1.0

<!-- ### Fixed -->


[PXP-675]: https://mindvalley.atlassian.net/browse/PXP-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ