### PR TITLE
PXP-660 feat: add cloudsql database metrics panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5767,6 +5767,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "similar",
+ "strum 0.26.1",
  "tabled",
  "thiserror",
  "time-humanize",

--- a/cli/src/auth/google_cloud.rs
+++ b/cli/src/auth/google_cloud.rs
@@ -153,7 +153,11 @@ pub async fn get_token_or_login(config: Option<Config>) -> String {
     .unwrap();
 
     authenticator
-        .token(&["https://www.googleapis.com/auth/logging.read"])
+        .token(&[
+            "https://www.googleapis.com/auth/logging.read",
+            "https://www.googleapis.com/auth/cloud-platform.read-only",
+            "https://www.googleapis.com/auth/monitoring.read",
+        ])
         .await
         .unwrap()
         .token()

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -14,7 +14,7 @@ use super::{action::Action, events::network::NetworkEvent, StatefulList};
 
 const DEFAULT_ROUTE: Route = Route {
     active_block: Block::Empty,
-    hovered_block: Block::Log(SelectedTab::GCloud),
+    hovered_block: Block::Middle(SelectedTab::GCloud),
 };
 
 #[derive(Default)]
@@ -45,7 +45,7 @@ pub enum DialogContext {
 pub enum Block {
     Build,
     Deployment,
-    Log(SelectedTab),
+    Middle(SelectedTab),
     Empty,
     Dialog(DialogContext),
 }

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -82,6 +82,8 @@ pub enum SelectedTab {
     GCloud,
     #[strum(to_string = "AppSignal")]
     AppSignal,
+    #[strum(to_string = "Databases")]
+    Databases,
 }
 
 impl SelectedTab {
@@ -89,6 +91,7 @@ impl SelectedTab {
         match index {
             1 => Some(SelectedTab::GCloud),
             2 => Some(SelectedTab::AppSignal),
+            3 => Some(SelectedTab::Databases),
             _ => None,
         }
     }

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -125,7 +125,7 @@ pub const MAX_LOG_ENTRIES_LENGTH: usize = 2_000;
 pub struct DatabasesState {
     pub is_active: bool,
     pub error: Option<String>,
-    pub database_instances: Vec<DatabaseMetrics>,
+    pub database_metrics: Vec<DatabaseMetrics>,
 }
 pub struct State {
     pub current_application: String,

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -788,8 +788,6 @@ async fn get_database_metrics(
                 if let Some(cluster) = application_data.k8s_cluster {
                     let database_metrics = match wk_client
                         .get_gcloud_database_metrics(
-                            &namespace,
-                            &version,
                             &cluster.google_project_id,
                             gcloud_access_token,
                         )

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, MutexGuard};
 use wukong_sdk::{
     graphql::AppsignalTimeFrame,
-    services::gcloud::{google::logging::v2::LogEntry, LogEntries, LogEntriesOptions},
+    services::gcloud::{
+        google::logging::v2::LogEntry, DatabaseInstance, LogEntries, LogEntriesOptions,
+    },
 };
 
 use crate::{
@@ -34,6 +36,7 @@ pub enum NetworkEvent {
     GetGCloudLogs,
     GetGCloudLogsTail,
     GetAppsignalData,
+    GetDatabaseMetrics,
     VerifyOktaRefreshToken,
     VerifyGCloudToken,
 }
@@ -54,6 +57,7 @@ pub async fn handle_network_event(
         NetworkEvent::VerifyOktaRefreshToken => verify_okta_refresh_token(app).await?,
         NetworkEvent::VerifyGCloudToken => verify_gcloud_token(app, &mut wk_client).await?,
         NetworkEvent::GetAppsignalData => fetch_appsignal_data(app, channel, config).await?,
+        NetworkEvent::GetDatabaseMetrics => get_database_metrics(app, &mut wk_client).await?,
     }
 
     Ok(())
@@ -752,6 +756,67 @@ async fn fetch_appsignal_data(
     app_ref.state.appsignal = appsignal_state.lock().await.clone();
     app_ref.state.is_fetching_appsignal_data = false;
     drop(app_ref);
+
+    Ok(())
+}
+
+async fn get_database_metrics(
+    app: Arc<Mutex<App>>,
+    wk_client: &mut WKClient,
+) -> Result<(), WKCliError> {
+    let mut app_ref = app.lock().await;
+    let application = app_ref.state.current_application.clone();
+    let namespace = app_ref.state.current_namespace.clone();
+    let version = app_ref.state.current_version.clone();
+
+    app_ref.state.databases.is_fetching = true;
+
+    drop(app_ref);
+    let gcloud_access_token = auth::google_cloud::get_token_or_login(None).await;
+    if let Some(namespace) = namespace {
+        if let Some(version) = version {
+            let application_resp = match wk_client
+                .fetch_application_with_k8s_cluster(&application, &namespace, &version)
+                .await
+            {
+                Ok(resp) => Ok(resp),
+                Err(err) => {
+                    let mut app_ref = app.lock().await;
+                    app_ref.state.databases.error = Some(format!("{err}"));
+                    Err(err)
+                }
+            }?
+            .application;
+
+            if let Some(application_data) = application_resp {
+                if let Some(cluster) = application_data.k8s_cluster {
+                    let database_metrics = match wk_client
+                        .get_gcloud_database_metrics(
+                            &namespace,
+                            &version,
+                            &cluster.google_project_id,
+                            gcloud_access_token,
+                        )
+                        .await
+                    {
+                        Ok(resp) => Ok(resp),
+                        Err(err) => {
+                            let mut app_ref = app.lock().await;
+                            app_ref.state.databases.error = Some(format!("{err}"));
+                            Err(err)
+                        }
+                    };
+                    if let Ok(database_metrics) = database_metrics {
+                        let mut app_ref = app.lock().await;
+                        app_ref.state.databases.database_instances = database_metrics;
+                    }
+                }
+            }
+        }
+    };
+
+    let mut app_ref = app.lock().await;
+    app_ref.state.databases.is_fetching = false;
 
     Ok(())
 }

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -804,7 +804,7 @@ async fn get_database_metrics(
                     };
                     if let Ok(database_metrics) = database_metrics {
                         let mut app_ref = app.lock().await;
-                        app_ref.state.databases.database_instances = database_metrics;
+                        app_ref.state.databases.database_metrics = database_metrics;
                     }
                 }
             }

--- a/cli/src/commands/tui/events/network.rs
+++ b/cli/src/commands/tui/events/network.rs
@@ -3,9 +3,7 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, MutexGuard};
 use wukong_sdk::{
     graphql::AppsignalTimeFrame,
-    services::gcloud::{
-        google::logging::v2::LogEntry, DatabaseInstance, LogEntries, LogEntriesOptions,
-    },
+    services::gcloud::{google::logging::v2::LogEntry, LogEntries, LogEntriesOptions},
 };
 
 use crate::{
@@ -764,12 +762,10 @@ async fn get_database_metrics(
     app: Arc<Mutex<App>>,
     wk_client: &mut WKClient,
 ) -> Result<(), WKCliError> {
-    let mut app_ref = app.lock().await;
+    let app_ref = app.lock().await;
     let application = app_ref.state.current_application.clone();
     let namespace = app_ref.state.current_namespace.clone();
     let version = app_ref.state.current_version.clone();
-
-    app_ref.state.databases.is_fetching = true;
 
     drop(app_ref);
     let gcloud_access_token = auth::google_cloud::get_token_or_login(None).await;
@@ -816,7 +812,7 @@ async fn get_database_metrics(
     };
 
     let mut app_ref = app.lock().await;
-    app_ref.state.databases.is_fetching = false;
+    app_ref.state.is_fetching_database_metrics = false;
 
     Ok(())
 }

--- a/cli/src/commands/tui/handlers/databases.rs
+++ b/cli/src/commands/tui/handlers/databases.rs
@@ -1,0 +1,15 @@
+use crate::commands::tui::{
+    app::{App, AppReturn, DatabasesState},
+    events::key::Key,
+};
+
+pub async fn handler(_key: Key, app: &mut App) -> AppReturn {
+    AppReturn::Continue
+}
+
+pub fn reset_database_panel_and_trigger_database_refetch(app: &mut App) {
+    app.state.databases = DatabasesState::default();
+    app.state.databases.is_fetching = true;
+
+    app.state.databases.error = None;
+}

--- a/cli/src/commands/tui/handlers/databases.rs
+++ b/cli/src/commands/tui/handlers/databases.rs
@@ -3,13 +3,13 @@ use crate::commands::tui::{
     events::key::Key,
 };
 
-pub async fn handler(_key: Key, app: &mut App) -> AppReturn {
+pub async fn handler(_key: Key, _app: &mut App) -> AppReturn {
     AppReturn::Continue
 }
 
 pub fn reset_database_panel_and_trigger_database_refetch(app: &mut App) {
     app.state.databases = DatabasesState::default();
-    app.state.databases.is_fetching = true;
+    app.state.is_fetching_database_metrics = true;
 
     app.state.databases.error = None;
 }

--- a/cli/src/commands/tui/handlers/empty.rs
+++ b/cli/src/commands/tui/handlers/empty.rs
@@ -44,7 +44,7 @@ async fn handle_search_logs(app: &mut App) -> AppReturn {
         );
     } else {
         log_search::reset_cursor(&mut app.state.search_bar_input);
-        app.set_current_route_state(None, Some(Block::Log(app.state.selected_tab)));
+        app.set_current_route_state(None, Some(Block::Middle(app.state.selected_tab)));
     }
 
     AppReturn::Continue
@@ -64,7 +64,7 @@ async fn handle_filter_logs(app: &mut App) -> AppReturn {
     } else {
         log_filter_exclude::reset_cursor(&mut app.state.filter_bar_exclude_input);
         log_filter_include::reset_cursor(&mut app.state.filter_bar_include_input);
-        app.set_current_route_state(None, Some(Block::Log(app.state.selected_tab)));
+        app.set_current_route_state(None, Some(Block::Middle(app.state.selected_tab)));
     }
 
     AppReturn::Continue
@@ -79,7 +79,7 @@ fn handle_key_events(key: Key, app: &mut App) -> AppReturn {
             AppReturn::Continue
         }
         key if common_key_events::down_event(key) => match app.get_current_route().hovered_block {
-            Block::Log(_) => {
+            Block::Middle(_) => {
                 app.set_current_route_state(None, Some(Block::Build));
                 AppReturn::Continue
             }
@@ -87,11 +87,11 @@ fn handle_key_events(key: Key, app: &mut App) -> AppReturn {
         },
         key if common_key_events::up_event(key) => match app.get_current_route().hovered_block {
             Block::Build => {
-                app.set_current_route_state(None, Some(Block::Log(app.state.selected_tab)));
+                app.set_current_route_state(None, Some(Block::Middle(app.state.selected_tab)));
                 AppReturn::Continue
             }
             Block::Deployment => {
-                app.set_current_route_state(None, Some(Block::Log(app.state.selected_tab)));
+                app.set_current_route_state(None, Some(Block::Middle(app.state.selected_tab)));
                 AppReturn::Continue
             }
             _ => AppReturn::Continue,

--- a/cli/src/commands/tui/handlers/log_filter_exclude.rs
+++ b/cli/src/commands/tui/handlers/log_filter_exclude.rs
@@ -9,7 +9,7 @@ pub async fn handler(key: Key, app: &mut App) -> AppReturn {
         key if common_key_events::back_event(key) => {
             app.state.show_filter_bar = false;
             app.set_current_route_state(
-                Some(Block::Log(app.state.selected_tab)),
+                Some(Block::Middle(app.state.selected_tab)),
                 Some(Block::Dialog(DialogContext::LogIncludeFilter)),
             );
         }

--- a/cli/src/commands/tui/handlers/log_filter_include.rs
+++ b/cli/src/commands/tui/handlers/log_filter_include.rs
@@ -9,7 +9,7 @@ pub async fn handler(key: Key, app: &mut App) -> AppReturn {
         key if common_key_events::back_event(key) => {
             app.state.show_filter_bar = false;
             app.set_current_route_state(
-                Some(Block::Log(app.state.selected_tab)),
+                Some(Block::Middle(app.state.selected_tab)),
                 Some(Block::Dialog(DialogContext::LogIncludeFilter)),
             );
         }

--- a/cli/src/commands/tui/handlers/log_search.rs
+++ b/cli/src/commands/tui/handlers/log_search.rs
@@ -9,7 +9,7 @@ pub async fn handler(key: Key, app: &mut App) -> AppReturn {
         key if common_key_events::back_event(key) => {
             app.state.show_search_bar = false;
             app.set_current_route_state(
-                Some(Block::Log(app.state.selected_tab)),
+                Some(Block::Middle(app.state.selected_tab)),
                 Some(Block::Dialog(DialogContext::LogIncludeFilter)),
             );
         }

--- a/cli/src/commands/tui/handlers/logs.rs
+++ b/cli/src/commands/tui/handlers/logs.rs
@@ -10,12 +10,12 @@ use wukong_sdk::services::gcloud::google::logging::r#type::LogSeverity;
 pub async fn handler(key: Key, app: &mut App) -> AppReturn {
     match key {
         key if common_key_events::back_event(key) => {
-            if let Some(Block::Log(_)) = app.state.expanded_block {
+            if let Some(Block::Middle(_)) = app.state.expanded_block {
                 app.state.expanded_block = None;
             } else {
                 app.set_current_route_state(
                     Some(Block::Empty),
-                    Some(Block::Log(app.state.selected_tab)),
+                    Some(Block::Middle(app.state.selected_tab)),
                 );
             }
         }
@@ -106,7 +106,7 @@ pub async fn handler(key: Key, app: &mut App) -> AppReturn {
             }
         }
         key if Action::from_key(key) == Some(Action::ExpandToFullScreen) => {
-            app.state.expanded_block = Some(Block::Log(app.state.selected_tab));
+            app.state.expanded_block = Some(Block::Middle(app.state.selected_tab));
         }
         key if Action::from_key(key) == Some(Action::LineWrapLogs) => {
             app.state.logs_textwrap = !app.state.logs_textwrap;

--- a/cli/src/commands/tui/handlers/middle.rs
+++ b/cli/src/commands/tui/handlers/middle.rs
@@ -7,12 +7,12 @@ use crate::commands::tui::{
 pub async fn handler(key: Key, app: &mut App) -> AppReturn {
     match key {
         key if common_key_events::back_event(key) => {
-            if let Some(Block::Log(_)) = app.state.expanded_block {
+            if let Some(Block::Middle(_)) = app.state.expanded_block {
                 app.state.expanded_block = None;
             } else {
                 app.set_current_route_state(
                     Some(Block::Empty),
-                    Some(Block::Log(app.state.selected_tab)),
+                    Some(Block::Middle(app.state.selected_tab)),
                 );
             }
         }
@@ -22,8 +22,8 @@ pub async fn handler(key: Key, app: &mut App) -> AppReturn {
                 if let Some(newly_selected_tab) = SelectedTab::get_tab(digit) {
                     app.state.selected_tab = newly_selected_tab;
                     app.set_current_route_state(
-                        Some(Block::Log(app.state.selected_tab)),
-                        Some(Block::Log(app.state.selected_tab)),
+                        Some(Block::Middle(app.state.selected_tab)),
+                        Some(Block::Middle(app.state.selected_tab)),
                     );
                 }
             }
@@ -35,8 +35,8 @@ pub async fn handler(key: Key, app: &mut App) -> AppReturn {
         //         if let Some(newly_selected_tab) = SelectedTab::get_tab(digit) {
         //             app.state.selected_tab = newly_selected_tab;
         //             app.set_current_route_state(
-        //                 Some(Block::Log(app.state.selected_tab)),
-        //                 Some(Block::Log(app.state.selected_tab)),
+        //                 Some(Block::Middle(app.state.selected_tab)),
+        //                 Some(Block::Middle(app.state.selected_tab)),
         //             );
         //         }
         //     }

--- a/cli/src/commands/tui/handlers/mod.rs
+++ b/cli/src/commands/tui/handlers/mod.rs
@@ -9,6 +9,7 @@ mod logs;
 mod namespace_selection;
 // mod time_filter_selection;
 mod appsignal;
+mod databases;
 mod middle;
 mod version_selection;
 
@@ -35,7 +36,10 @@ async fn handle_block_events(key: Key, app: &mut App) -> AppReturn {
             match selected_tab {
                 SelectedTab::GCloud => logs::handler(key, app).await,
                 SelectedTab::AppSignal => appsignal::handler(key, app).await,
-                SelectedTab::Databases => build::handler(key, app).await,
+                SelectedTab::Databases => {
+                    // println!("About to Databases handler");
+                    databases::handler(key, app).await
+                }
             }
         }
         Block::Dialog(DialogContext::NamespaceSelection) => {

--- a/cli/src/commands/tui/handlers/mod.rs
+++ b/cli/src/commands/tui/handlers/mod.rs
@@ -31,7 +31,7 @@ async fn handle_block_events(key: Key, app: &mut App) -> AppReturn {
 
     match current_route.active_block {
         Block::Empty => empty::handler(key, app).await, // Main Input
-        Block::Log(selected_tab) => {
+        Block::Middle(selected_tab) => {
             middle::handler(key, app).await;
             match selected_tab {
                 SelectedTab::GCloud => logs::handler(key, app).await,

--- a/cli/src/commands/tui/handlers/mod.rs
+++ b/cli/src/commands/tui/handlers/mod.rs
@@ -35,6 +35,7 @@ async fn handle_block_events(key: Key, app: &mut App) -> AppReturn {
             match selected_tab {
                 SelectedTab::GCloud => logs::handler(key, app).await,
                 SelectedTab::AppSignal => appsignal::handler(key, app).await,
+                SelectedTab::Databases => build::handler(key, app).await,
             }
         }
         Block::Dialog(DialogContext::NamespaceSelection) => {

--- a/cli/src/commands/tui/handlers/namespace_selection.rs
+++ b/cli/src/commands/tui/handlers/namespace_selection.rs
@@ -1,5 +1,6 @@
 use super::{
     appsignal::reset_appsignal_panel_and_trigger_appsignal_refetch, common_key_events,
+    databases::reset_database_panel_and_trigger_database_refetch,
     logs::reset_log_panel_and_trigger_log_refetch,
 };
 
@@ -54,4 +55,7 @@ async fn fetch_and_reset_polling(app: &mut App, selected_version: String) {
 
     reset_appsignal_panel_and_trigger_appsignal_refetch(app);
     app.dispatch(NetworkEvent::GetAppsignalData).await;
+
+    reset_database_panel_and_trigger_database_refetch(app);
+    app.dispatch(NetworkEvent::GetDatabaseMetrics).await;
 }

--- a/cli/src/commands/tui/handlers/namespace_selection.rs
+++ b/cli/src/commands/tui/handlers/namespace_selection.rs
@@ -14,7 +14,7 @@ pub async fn handler(key: Key, app: &mut App) -> AppReturn {
         key if common_key_events::back_event(key) => {
             app.set_current_route_state(
                 Some(Block::Empty),
-                Some(Block::Log(app.state.selected_tab)),
+                Some(Block::Middle(app.state.selected_tab)),
             );
         }
         key if common_key_events::back_event(key) => app.push_navigation_stack(Block::Empty),

--- a/cli/src/commands/tui/handlers/time_filter_selection.rs
+++ b/cli/src/commands/tui/handlers/time_filter_selection.rs
@@ -8,7 +8,7 @@ use crate::commands::tui::{
 pub async fn handler(key: Key, app: &mut App) -> AppReturn {
     match key {
         key if common_key_events::back_event(key) => {
-            app.set_current_route_state(Some(Block::Log), Some(Block::Log));
+            app.set_current_route_state(Some(Block::Middle), Some(Block::Middle));
         }
         key if common_key_events::back_event(key) => app.push_navigation_stack(Block::Empty),
         key if common_key_events::down_event(key) => app.time_filter_selections.next(),
@@ -37,5 +37,5 @@ async fn handle_enter_key(app: &mut App) {
         reset_log_panel_and_trigger_log_refetch(app);
     }
 
-    app.push_navigation_stack(Block::Log)
+    app.push_navigation_stack(Block::Middle)
 }

--- a/cli/src/commands/tui/handlers/version_selection.rs
+++ b/cli/src/commands/tui/handlers/version_selection.rs
@@ -1,4 +1,7 @@
-use super::{common_key_events, logs::reset_log_panel_and_trigger_log_refetch};
+use super::{
+    common_key_events, databases::reset_database_panel_and_trigger_database_refetch,
+    logs::reset_log_panel_and_trigger_log_refetch,
+};
 
 use crate::commands::tui::{
     app::{App, AppReturn, Block},
@@ -47,4 +50,7 @@ async fn fetch_and_reset_polling(app: &mut App, selected_version: String) {
     reset_log_panel_and_trigger_log_refetch(app);
 
     app.dispatch(NetworkEvent::GetBuilds).await;
+
+    reset_database_panel_and_trigger_database_refetch(app);
+    app.dispatch(NetworkEvent::GetDatabaseMetrics).await;
 }

--- a/cli/src/commands/tui/handlers/version_selection.rs
+++ b/cli/src/commands/tui/handlers/version_selection.rs
@@ -13,7 +13,7 @@ pub async fn handler(key: Key, app: &mut App) -> AppReturn {
         key if common_key_events::back_event(key) => {
             app.set_current_route_state(
                 Some(Block::Empty),
-                Some(Block::Log(app.state.selected_tab)),
+                Some(Block::Middle(app.state.selected_tab)),
             );
         }
         key if common_key_events::back_event(key) => app.push_navigation_stack(Block::Empty),

--- a/cli/src/commands/tui/mod.rs
+++ b/cli/src/commands/tui/mod.rs
@@ -140,6 +140,7 @@ pub async fn start_ui(app: &Arc<Mutex<App>>) -> std::io::Result<bool> {
     let mut is_welcome_screen_first_frame = true;
     let mut is_first_fetch_builds = true;
     let mut is_first_fetch_appsignals = true;
+    let mut is_first_fetch_database_metrics = true;
 
     let mut app_ref = app.lock().await;
 
@@ -213,6 +214,11 @@ pub async fn start_ui(app: &Arc<Mutex<App>>) -> std::io::Result<bool> {
             if is_first_fetch_appsignals {
                 app_ref.dispatch(NetworkEvent::GetAppsignalData).await;
                 is_first_fetch_appsignals = false;
+            }
+
+            if is_first_fetch_database_metrics {
+                app_ref.dispatch(NetworkEvent::GetDatabaseMetrics).await;
+                is_first_fetch_database_metrics = false;
             }
         }
     }

--- a/cli/src/commands/tui/ui/appsignal.rs
+++ b/cli/src/commands/tui/ui/appsignal.rs
@@ -2,7 +2,7 @@ use ratatui::{
     prelude::{Backend, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Span, Text},
-        widgets::{Block as WidgetBlock, Borders, Cell, Padding, Paragraph, Row, Table},
+    widgets::{Block as WidgetBlock, Borders, Cell, Padding, Paragraph, Row, Table},
     Frame,
 };
 

--- a/cli/src/commands/tui/ui/appsignal.rs
+++ b/cli/src/commands/tui/ui/appsignal.rs
@@ -2,7 +2,7 @@ use ratatui::{
     prelude::{Backend, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Span, Text},
-    widgets::{Block as WidgetBlock, Borders, Cell, Padding, Paragraph, Row, Table},
+        widgets::{Block as WidgetBlock, Borders, Cell, Padding, Paragraph, Row, Table},
     Frame,
 };
 

--- a/cli/src/commands/tui/ui/databases.rs
+++ b/cli/src/commands/tui/ui/databases.rs
@@ -26,7 +26,7 @@ impl DatabasesWidget {
         let rows = app
             .state
             .databases
-            .database_instances
+            .database_metrics
             .iter()
             .map(|database_instance| {
                 Row::new(vec![

--- a/cli/src/commands/tui/ui/databases.rs
+++ b/cli/src/commands/tui/ui/databases.rs
@@ -32,19 +32,19 @@ impl DatabasesWidget {
                 Row::new(vec![
                     Cell::from(Span::styled(database_instance.name.to_string(), name_style)),
                     Cell::from(Span::styled(
-                        format!("{:>15.2}", database_instance.cpu_utilization),
+                        format!("{:>14.2}%", database_instance.cpu_utilization),
                         name_style,
                     )),
                     Cell::from(Span::styled(
-                        format!("{:>12.2}", database_instance.memory_usage),
+                        format!("{:>11.2}%", database_instance.memory_usage),
                         name_style,
                     )),
                     Cell::from(Span::styled(
-                        format!("{:>11.2}", database_instance.memory_free),
+                        format!("{:>10.2}%", database_instance.memory_free),
                         name_style,
                     )),
                     Cell::from(Span::styled(
-                        format!("{:>13.2}", database_instance.memory_cache),
+                        format!("{:>12.2}%", database_instance.memory_cache),
                         name_style,
                     )),
                     Cell::from(Span::styled(

--- a/cli/src/commands/tui/ui/databases.rs
+++ b/cli/src/commands/tui/ui/databases.rs
@@ -16,7 +16,7 @@ impl DatabasesWidget {
             return;
         }
         // it will show loader only on the first call
-        if app.state.databases.is_fetching {
+        if app.state.is_fetching_database_metrics {
             let loading_message = create_loading_block();
             frame.render_widget(loading_message, rect);
             return;

--- a/cli/src/commands/tui/ui/databases.rs
+++ b/cli/src/commands/tui/ui/databases.rs
@@ -30,25 +30,28 @@ impl DatabasesWidget {
             .iter()
             .map(|database_instance| {
                 Row::new(vec![
-                    Cell::from(Span::styled(database_instance.name.to_string(), name_style)),
                     Cell::from(Span::styled(
-                        database_instance.cpu_utilization.to_string(),
+                        format!("{:}", database_instance.name),
                         name_style,
                     )),
                     Cell::from(Span::styled(
-                        database_instance.memory_usage.to_string(),
+                        format!("{:>15.2}", database_instance.cpu_utilization),
                         name_style,
                     )),
                     Cell::from(Span::styled(
-                        database_instance.memory_free.to_string(),
+                        format!("{:>12.2}", database_instance.memory_usage),
                         name_style,
                     )),
                     Cell::from(Span::styled(
-                        database_instance.memory_cache.to_string(),
+                        format!("{:>11.2}", database_instance.memory_free),
                         name_style,
                     )),
                     Cell::from(Span::styled(
-                        database_instance.connections_count.to_string(),
+                        format!("{:>13.2}", database_instance.memory_cache),
+                        name_style,
+                    )),
+                    Cell::from(Span::styled(
+                        format!("{:>17}", database_instance.connections_count),
                         name_style,
                     )),
                 ])
@@ -64,7 +67,14 @@ impl DatabasesWidget {
                 Cell::from(Span::styled("Memory Cached", name_style)),
                 Cell::from(Span::styled("Connections Count", name_style)),
             ]))
-            .widths(&[Constraint::Min(20), Constraint::Length(1000)])
+            .widths(&[
+                Constraint::Min(70),
+                Constraint::Length(18),
+                Constraint::Length(15),
+                Constraint::Length(15),
+                Constraint::Length(15),
+                Constraint::Length(18),
+            ])
             .column_spacing(1);
 
         frame.render_widget(widget, rect);
@@ -77,11 +87,6 @@ fn create_loading_block() -> Paragraph<'static> {
         Style::default().fg(Color::White),
     ))
     .block(WidgetBlock::default())
-}
-
-fn create_custom_text_block(text: String) -> Paragraph<'static> {
-    Paragraph::new(Text::styled(text, Style::default().fg(Color::White)))
-        .block(WidgetBlock::default())
 }
 
 fn create_error_block(error: &str) -> Paragraph<'_> {

--- a/cli/src/commands/tui/ui/databases.rs
+++ b/cli/src/commands/tui/ui/databases.rs
@@ -1,0 +1,50 @@
+use crate::commands::tui::app::{App};
+use ratatui::{
+    prelude::{Backend, Constraint, Rect},
+    style::{Color, Style},
+    text::Span,
+    widgets::{Cell, Row, Table},
+    Frame,
+};
+pub struct DatabasesWidget;
+
+impl DatabasesWidget {
+    pub fn draw<B: Backend>(_app: &mut App, frame: &mut Frame<B>, rect: Rect) {
+        let name_style = Style::default().fg(Color::White);
+
+        // Get database instances, cpu usage, free memory, and connections count from the cloudsql client
+        let database_instances = "instance1"; //cloudsql_client.get_database_instances();
+        let cpu_usage = "90%"; //cloudsql_client.get_cpu_usage();
+        let free_memory = "10M"; //cloudsql_client.get_free_memory();
+        let connections_count = "1000/5000"; //cloudsql_client.get_connections_count();
+
+        let rows = vec![
+            Row::new(vec![
+                Cell::from(Span::styled("Database Instances", name_style)),
+                Cell::from(Span::styled(database_instances.to_string(), name_style)),
+            ]),
+            Row::new(vec![
+                Cell::from(Span::styled("CPU Usage", name_style)),
+                Cell::from(Span::styled(cpu_usage.to_string(), name_style)),
+            ]),
+            Row::new(vec![
+                Cell::from(Span::styled("Free Memory", name_style)),
+                Cell::from(Span::styled(free_memory.to_string(), name_style)),
+            ]),
+            Row::new(vec![
+                Cell::from(Span::styled("Connections Count", name_style)),
+                Cell::from(Span::styled(connections_count.to_string(), name_style)),
+            ]),
+        ];
+
+        let widget = Table::new(rows)
+            .header(Row::new(vec![
+                Cell::from(Span::styled("Metric", name_style)),
+                Cell::from(Span::styled("Value", name_style)),
+            ]))
+            .widths(&[Constraint::Min(20), Constraint::Length(1000)])
+            .column_spacing(1);
+
+        frame.render_widget(widget, rect);
+    }
+}

--- a/cli/src/commands/tui/ui/databases.rs
+++ b/cli/src/commands/tui/ui/databases.rs
@@ -30,10 +30,7 @@ impl DatabasesWidget {
             .iter()
             .map(|database_instance| {
                 Row::new(vec![
-                    Cell::from(Span::styled(
-                        format!("{:}", database_instance.name),
-                        name_style,
-                    )),
+                    Cell::from(Span::styled(database_instance.name.to_string(), name_style)),
                     Cell::from(Span::styled(
                         format!("{:>15.2}", database_instance.cpu_utilization),
                         name_style,

--- a/cli/src/commands/tui/ui/databases.rs
+++ b/cli/src/commands/tui/ui/databases.rs
@@ -21,46 +21,48 @@ impl DatabasesWidget {
             frame.render_widget(loading_message, rect);
             return;
         }
-
-        // todo!();
         let name_style = Style::default().fg(Color::White);
 
-        // Get database instances, cpu usage, free memory, and connections count from the cloudsql client
-        let cpu_usage = "90%"; //cloudsql_client.get_cpu_usage();
-        let free_memory = "10M"; //cloudsql_client.get_free_memory();
-        let connections_count = "1000/5000"; //cloudsql_client.get_connections_count();
-
-        let rows = vec![
-            Row::new(vec![
-                Cell::from(Span::styled("Database Instances", name_style)),
-                Cell::from(Span::styled(
-                    app.state.databases.database_instances[0].name.to_string(),
-                    name_style,
-                )),
-            ]),
-            Row::new(vec![
-                Cell::from(Span::styled("CPU Utilization", name_style)),
-                Cell::from(Span::styled(
-                    app.state.databases.database_instances[0]
-                        .cpu_utilization
-                        .to_string(),
-                    name_style,
-                )),
-            ]),
-            Row::new(vec![
-                Cell::from(Span::styled("Free Memory", name_style)),
-                Cell::from(Span::styled(free_memory.to_string(), name_style)),
-            ]),
-            Row::new(vec![
-                Cell::from(Span::styled("Connections Count", name_style)),
-                Cell::from(Span::styled(connections_count.to_string(), name_style)),
-            ]),
-        ];
+        let rows = app
+            .state
+            .databases
+            .database_instances
+            .iter()
+            .map(|database_instance| {
+                Row::new(vec![
+                    Cell::from(Span::styled(database_instance.name.to_string(), name_style)),
+                    Cell::from(Span::styled(
+                        database_instance.cpu_utilization.to_string(),
+                        name_style,
+                    )),
+                    Cell::from(Span::styled(
+                        database_instance.memory_usage.to_string(),
+                        name_style,
+                    )),
+                    Cell::from(Span::styled(
+                        database_instance.memory_free.to_string(),
+                        name_style,
+                    )),
+                    Cell::from(Span::styled(
+                        database_instance.memory_cache.to_string(),
+                        name_style,
+                    )),
+                    Cell::from(Span::styled(
+                        database_instance.connections_count.to_string(),
+                        name_style,
+                    )),
+                ])
+            })
+            .collect::<Vec<Row>>();
 
         let widget = Table::new(rows)
             .header(Row::new(vec![
-                Cell::from(Span::styled("Metric", name_style)),
-                Cell::from(Span::styled("Value", name_style)),
+                Cell::from(Span::styled("Database ID", name_style)),
+                Cell::from(Span::styled("CPU Utilization", name_style)),
+                Cell::from(Span::styled("Memory Usage", name_style)),
+                Cell::from(Span::styled("Memory Free", name_style)),
+                Cell::from(Span::styled("Memory Cached", name_style)),
+                Cell::from(Span::styled("Connections Count", name_style)),
             ]))
             .widths(&[Constraint::Min(20), Constraint::Length(1000)])
             .column_spacing(1);

--- a/cli/src/commands/tui/ui/databases.rs
+++ b/cli/src/commands/tui/ui/databases.rs
@@ -1,19 +1,31 @@
-use crate::commands::tui::app::{App};
+use crate::commands::tui::app::App;
 use ratatui::{
     prelude::{Backend, Constraint, Rect},
     style::{Color, Style},
-    text::Span,
-    widgets::{Cell, Row, Table},
+    text::{Span, Text},
+    widgets::{Block as WidgetBlock, Cell, Padding, Paragraph, Row, Table},
     Frame,
 };
 pub struct DatabasesWidget;
 
 impl DatabasesWidget {
-    pub fn draw<B: Backend>(_app: &mut App, frame: &mut Frame<B>, rect: Rect) {
+    pub fn draw<B: Backend>(app: &mut App, frame: &mut Frame<B>, rect: Rect) {
+        if let Some(ref error) = app.state.databases.error {
+            let error_message = create_error_block(error);
+            frame.render_widget(error_message, rect);
+            return;
+        }
+        // it will show loader only on the first call
+        if app.state.databases.is_fetching {
+            let loading_message = create_loading_block();
+            frame.render_widget(loading_message, rect);
+            return;
+        }
+
+        // todo!();
         let name_style = Style::default().fg(Color::White);
 
         // Get database instances, cpu usage, free memory, and connections count from the cloudsql client
-        let database_instances = "instance1"; //cloudsql_client.get_database_instances();
         let cpu_usage = "90%"; //cloudsql_client.get_cpu_usage();
         let free_memory = "10M"; //cloudsql_client.get_free_memory();
         let connections_count = "1000/5000"; //cloudsql_client.get_connections_count();
@@ -21,11 +33,19 @@ impl DatabasesWidget {
         let rows = vec![
             Row::new(vec![
                 Cell::from(Span::styled("Database Instances", name_style)),
-                Cell::from(Span::styled(database_instances.to_string(), name_style)),
+                Cell::from(Span::styled(
+                    app.state.databases.database_instances[0].name.to_string(),
+                    name_style,
+                )),
             ]),
             Row::new(vec![
-                Cell::from(Span::styled("CPU Usage", name_style)),
-                Cell::from(Span::styled(cpu_usage.to_string(), name_style)),
+                Cell::from(Span::styled("CPU Utilization", name_style)),
+                Cell::from(Span::styled(
+                    app.state.databases.database_instances[0]
+                        .cpu_utilization
+                        .to_string(),
+                    name_style,
+                )),
             ]),
             Row::new(vec![
                 Cell::from(Span::styled("Free Memory", name_style)),
@@ -47,4 +67,22 @@ impl DatabasesWidget {
 
         frame.render_widget(widget, rect);
     }
+}
+
+fn create_loading_block() -> Paragraph<'static> {
+    Paragraph::new(Text::styled(
+        "Loading...",
+        Style::default().fg(Color::White),
+    ))
+    .block(WidgetBlock::default())
+}
+
+fn create_custom_text_block(text: String) -> Paragraph<'static> {
+    Paragraph::new(Text::styled(text, Style::default().fg(Color::White)))
+        .block(WidgetBlock::default())
+}
+
+fn create_error_block(error: &str) -> Paragraph<'_> {
+    Paragraph::new(Text::styled(error, Style::default().fg(Color::White)))
+        .block(WidgetBlock::default().padding(Padding::new(1, 1, 0, 0)))
 }

--- a/cli/src/commands/tui/ui/middle.rs
+++ b/cli/src/commands/tui/ui/middle.rs
@@ -10,7 +10,8 @@ use ratatui::{
 use strum::IntoEnumIterator;
 
 use super::{
-    appsignal::AppsignalWidget, databases::DatabasesWidget, centered_rect_by_padding, logs::LogsWidget, util::get_color
+    appsignal::AppsignalWidget, centered_rect_by_padding, databases::DatabasesWidget,
+    logs::LogsWidget, util::get_color,
 };
 
 pub struct MiddleWidget;
@@ -20,13 +21,13 @@ impl MiddleWidget {
         app.state.logs_widget_width = rect.width;
         app.state.logs_widget_height = rect.height;
 
-        app.update_draw_lock(Block::Log(app.state.selected_tab), rect);
+        app.update_draw_lock(Block::Middle(app.state.selected_tab), rect);
 
         let current_route = app.get_current_route();
 
         let highlight_state = (
-            matches!(current_route.active_block, Block::Log(_)),
-            matches!(current_route.hovered_block, Block::Log(_)),
+            matches!(current_route.active_block, Block::Middle(_)),
+            matches!(current_route.hovered_block, Block::Middle(_)),
         );
 
         let titles = SelectedTab::iter()

--- a/cli/src/commands/tui/ui/middle.rs
+++ b/cli/src/commands/tui/ui/middle.rs
@@ -10,7 +10,7 @@ use ratatui::{
 use strum::IntoEnumIterator;
 
 use super::{
-    appsignal::AppsignalWidget, centered_rect_by_padding, logs::LogsWidget, util::get_color,
+    appsignal::AppsignalWidget, databases::DatabasesWidget, centered_rect_by_padding, logs::LogsWidget, util::get_color
 };
 
 pub struct MiddleWidget;
@@ -53,6 +53,7 @@ impl MiddleWidget {
         match app.state.selected_tab {
             SelectedTab::GCloud => LogsWidget::draw(app, frame, inner_rect),
             SelectedTab::AppSignal => AppsignalWidget::draw(app, frame, inner_rect),
+            SelectedTab::Databases => DatabasesWidget::draw(app, frame, inner_rect),
         }
     }
 }

--- a/cli/src/commands/tui/ui/mod.rs
+++ b/cli/src/commands/tui/ui/mod.rs
@@ -49,7 +49,7 @@ where
             Block::Deployment => {
                 DeploymentWidget::draw(app, frame, bottom);
             }
-            Block::Log(selected_tab) => match selected_tab {
+            Block::Middle(selected_tab) => match selected_tab {
                 SelectedTab::GCloud => LogsWidget::draw(app, frame, bottom),
                 SelectedTab::AppSignal => AppsignalWidget::draw(app, frame, bottom),
                 SelectedTab::Databases => DatabasesWidget::draw(app, frame, bottom),

--- a/cli/src/commands/tui/ui/mod.rs
+++ b/cli/src/commands/tui/ui/mod.rs
@@ -17,6 +17,7 @@ use super::app::{App, Block, DialogContext, SelectedTab};
 
 mod application;
 mod builds;
+mod databases;
 mod deployment;
 mod help;
 mod logs;
@@ -51,6 +52,7 @@ where
             Block::Log(selected_tab) => match selected_tab {
                 SelectedTab::GCloud => LogsWidget::draw(app, frame, bottom),
                 SelectedTab::AppSignal => AppsignalWidget::draw(app, frame, bottom),
+                SelectedTab::Databases => BuildsWidget::draw(app, frame, bottom),
             },
             Block::Empty => todo!(),
             Block::Dialog(_) => todo!(),

--- a/cli/src/commands/tui/ui/mod.rs
+++ b/cli/src/commands/tui/ui/mod.rs
@@ -8,9 +8,9 @@ use ratatui::{
 
 use self::{
     application::ApplicationWidget, appsignal::AppsignalWidget, builds::BuildsWidget,
-    deployment::DeploymentWidget, help::HelpWidget, logs::LogsWidget, middle::MiddleWidget,
-    namespace_selection::NamespaceSelectionWidget, version_selection::VersionSelectionWidget,
-    welcome::WelcomeWidget,
+    databases::DatabasesWidget, deployment::DeploymentWidget, help::HelpWidget, logs::LogsWidget,
+    middle::MiddleWidget, namespace_selection::NamespaceSelectionWidget,
+    version_selection::VersionSelectionWidget, welcome::WelcomeWidget,
 };
 
 use super::app::{App, Block, DialogContext, SelectedTab};
@@ -52,7 +52,7 @@ where
             Block::Log(selected_tab) => match selected_tab {
                 SelectedTab::GCloud => LogsWidget::draw(app, frame, bottom),
                 SelectedTab::AppSignal => AppsignalWidget::draw(app, frame, bottom),
-                SelectedTab::Databases => BuildsWidget::draw(app, frame, bottom),
+                SelectedTab::Databases => DatabasesWidget::draw(app, frame, bottom),
             },
             Block::Empty => todo!(),
             Block::Dialog(_) => todo!(),

--- a/cli/src/wukong_client.rs
+++ b/cli/src/wukong_client.rs
@@ -315,11 +315,11 @@ impl WKClient {
     #[wukong_telemetry(api_event = "fetch_gcloud_log_entries")]
     pub async fn get_gcloud_log_entries(
         &self,
-        optons: LogEntriesOptions,
+        options: LogEntriesOptions,
         access_token: String,
     ) -> Result<LogEntries, WKCliError> {
         self.inner
-            .get_gcloud_log_entries(optons, access_token)
+            .get_gcloud_log_entries(options, access_token)
             .await
     }
 

--- a/cli/src/wukong_client.rs
+++ b/cli/src/wukong_client.rs
@@ -16,7 +16,7 @@ use wukong_sdk::{
         multi_branch_pipeline_query, pipeline_query, pipelines_query, AppsignalTimeFrame,
     },
     services::{
-        gcloud::{LogEntries, LogEntriesOptions, TokenInfo},
+        gcloud::{DatabaseInstance, LogEntries, LogEntriesOptions, TokenInfo},
         vault::client::FetchSecretsData,
     },
     WKClient as WKSdkClient, WKConfig,
@@ -413,5 +413,18 @@ impl WKClient {
     ) -> Result<appsignal_apps_query::ResponseData, WKCliError> {
         self.check_and_refresh_tokens().await?;
         self.inner.fetch_appsignal_apps().await
+    }
+
+    #[wukong_telemetry(api_event = "get_gcloud_database_metrics")]
+    pub async fn get_gcloud_database_metrics(
+        &self,
+        namespace: &str,
+        application: &str,
+        project_id: &str,
+        access_token: String,
+    ) -> Result<Vec<DatabaseInstance>, WKCliError> {
+        self.inner
+            .get_gcloud_database_metrics(application, namespace, project_id, access_token)
+            .await
     }
 }

--- a/cli/src/wukong_client.rs
+++ b/cli/src/wukong_client.rs
@@ -418,13 +418,11 @@ impl WKClient {
     #[wukong_telemetry(api_event = "get_gcloud_database_metrics")]
     pub async fn get_gcloud_database_metrics(
         &self,
-        namespace: &str,
-        application: &str,
         project_id: &str,
         access_token: String,
     ) -> Result<Vec<DatabaseMetrics>, WKCliError> {
         self.inner
-            .get_gcloud_database_metrics(application, namespace, project_id, access_token)
+            .get_gcloud_database_metrics(project_id, access_token)
             .await
     }
 }

--- a/cli/src/wukong_client.rs
+++ b/cli/src/wukong_client.rs
@@ -16,7 +16,7 @@ use wukong_sdk::{
         multi_branch_pipeline_query, pipeline_query, pipelines_query, AppsignalTimeFrame,
     },
     services::{
-        gcloud::{DatabaseInstance, LogEntries, LogEntriesOptions, TokenInfo},
+        gcloud::{DatabaseMetrics, LogEntries, LogEntriesOptions, TokenInfo},
         vault::client::FetchSecretsData,
     },
     WKClient as WKSdkClient, WKConfig,
@@ -422,7 +422,7 @@ impl WKClient {
         application: &str,
         project_id: &str,
         access_token: String,
-    ) -> Result<Vec<DatabaseInstance>, WKCliError> {
+    ) -> Result<Vec<DatabaseMetrics>, WKCliError> {
         self.inner
             .get_gcloud_database_metrics(application, namespace, project_id, access_token)
             .await

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -80,6 +80,9 @@ futures = { version = "0.3.28", default-features = false, features = [
 ] }
 urlencoding = "2.1.2"
 
+# Utils
+strum = { version = "0.26.1", features = ["derive"] }
+
 [dependencies.tree-sitter-elixir]
 git = "https://github.com/elixir-lang/tree-sitter-elixir"
 tag = "v0.1.0"

--- a/sdk/build.rs
+++ b/sdk/build.rs
@@ -19,6 +19,10 @@ fn main() {
                     "{}/proto/googleapis/google/monitoring/v3/metric.proto",
                     cargo_manifest_dir
                 ),
+                format!(
+                    "{}/proto/googleapis/google/monitoring/v3/metric_service.proto",
+                    cargo_manifest_dir
+                ),
             ],
             &[format!("{}/proto/googleapis", cargo_manifest_dir)], // specify the root location to search proto dependencies
         )

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -185,6 +185,8 @@ pub enum GCloudError {
     ResponseError(#[from] tonic::Status),
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
+    #[error("Invalid metric type.")]
+    InvalidMetricType,
 }
 
 // Secret Extractor Error

--- a/sdk/src/services/gcloud/api/google.api.rs
+++ b/sdk/src/services/gcloud/api/google.api.rs
@@ -719,19 +719,6 @@ pub struct MethodSettings {
     /// seconds: 54000 # 90 minutes
     #[prost(message, optional, tag = "2")]
     pub long_running: ::core::option::Option<method_settings::LongRunning>,
-    /// List of top-level fields of the request message, that should be
-    /// automatically populated by the client libraries based on their
-    /// (google.api.field_info).format. Currently supported format: UUID4.
-    ///
-    /// Example of a YAML configuration:
-    ///
-    /// publishing:
-    /// method_settings:
-    /// - selector: google.example.v1.ExampleService.CreateExample
-    /// auto_populated_fields:
-    /// - request_id
-    #[prost(string, repeated, tag = "3")]
-    pub auto_populated_fields: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Nested message and enum types in `MethodSettings`.
 pub mod method_settings {
@@ -897,19 +884,6 @@ pub enum FieldBehavior {
     /// a non-empty value will be returned. The user will not be aware of what
     /// non-empty value to expect.
     NonEmptyDefault = 7,
-    /// Denotes that the field in a resource (a message annotated with
-    /// google.api.resource) is used in the resource name to uniquely identify the
-    /// resource. For AIP-compliant APIs, this should only be applied to the
-    /// `name` field on the resource.
-    ///
-    /// This behavior should not be applied to references to other resources within
-    /// the message.
-    ///
-    /// The identifier field of resources often have different field behavior
-    /// depending on the request it is embedded in (e.g. for Create methods name
-    /// is optional and unused, while for Update methods it is required). Instead
-    /// of method-specific annotations, only `IDENTIFIER` is required.
-    Identifier = 8,
 }
 impl FieldBehavior {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -926,7 +900,6 @@ impl FieldBehavior {
             FieldBehavior::Immutable => "IMMUTABLE",
             FieldBehavior::UnorderedList => "UNORDERED_LIST",
             FieldBehavior::NonEmptyDefault => "NON_EMPTY_DEFAULT",
-            FieldBehavior::Identifier => "IDENTIFIER",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -940,7 +913,6 @@ impl FieldBehavior {
             "IMMUTABLE" => Some(Self::Immutable),
             "UNORDERED_LIST" => Some(Self::UnorderedList),
             "NON_EMPTY_DEFAULT" => Some(Self::NonEmptyDefault),
-            "IDENTIFIER" => Some(Self::Identifier),
             _ => None,
         }
     }

--- a/sdk/src/services/gcloud/api/google.cloud.sql.v1.rs
+++ b/sdk/src/services/gcloud/api/google.cloud.sql.v1.rs
@@ -33,17 +33,7 @@ pub struct ApiWarning {
 }
 /// Nested message and enum types in `ApiWarning`.
 pub mod api_warning {
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum SqlApiWarningCode {
         /// An unknown or unset warning type from Cloud SQL API.
@@ -95,17 +85,7 @@ pub struct BackupRetentionSettings {
 /// Nested message and enum types in `BackupRetentionSettings`.
 pub mod backup_retention_settings {
     /// The units that retained_backups specifies, we only support COUNT.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum RetentionUnit {
         /// Backup retention unit is unspecified, will be treated as COUNT.
@@ -311,9 +291,7 @@ pub struct DemoteMasterConfiguration {
     /// replication connection and is stored by MySQL in a file named
     /// `master.info` in the data directory.
     #[prost(message, optional, tag = "2")]
-    pub mysql_replica_configuration: ::core::option::Option<
-        DemoteMasterMySqlReplicaConfiguration,
-    >,
+    pub mysql_replica_configuration: ::core::option::Option<DemoteMasterMySqlReplicaConfiguration>,
 }
 /// Read-replica configuration specific to MySQL databases.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -420,9 +398,7 @@ pub mod export_context {
         #[prost(message, optional, tag = "2")]
         pub schema_only: ::core::option::Option<bool>,
         #[prost(message, optional, tag = "3")]
-        pub mysql_export_options: ::core::option::Option<
-            sql_export_options::MysqlExportOptions,
-        >,
+        pub mysql_export_options: ::core::option::Option<sql_export_options::MysqlExportOptions>,
     }
     /// Nested message and enum types in `SqlExportOptions`.
     pub mod sql_export_options {
@@ -529,9 +505,7 @@ pub mod import_context {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct SqlBakImportOptions {
         #[prost(message, optional, tag = "1")]
-        pub encryption_options: ::core::option::Option<
-            sql_bak_import_options::EncryptionOptions,
-        >,
+        pub encryption_options: ::core::option::Option<sql_bak_import_options::EncryptionOptions>,
         /// Whether or not the backup set being restored is striped.
         /// Applies only to Cloud SQL for SQL Server.
         #[prost(message, optional, tag = "2")]
@@ -864,17 +838,7 @@ pub struct Operation {
 /// Nested message and enum types in `Operation`.
 pub mod operation {
     /// The type of Cloud SQL operation.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum SqlOperationType {
         /// Unknown operation type.
@@ -1053,17 +1017,7 @@ pub mod operation {
         }
     }
     /// The status of an operation.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum SqlOperationStatus {
         /// The state of the operation is unknown.
@@ -1152,17 +1106,7 @@ pub struct PasswordValidationPolicy {
 /// Nested message and enum types in `PasswordValidationPolicy`.
 pub mod password_validation_policy {
     /// The complexity choices of the password.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Complexity {
         /// Complexity check is not specified.
@@ -1214,9 +1158,7 @@ pub struct Settings {
     /// (Deprecated) Applied to First Generation instances only.
     #[deprecated]
     #[prost(string, repeated, tag = "2")]
-    pub authorized_gae_applications: ::prost::alloc::vec::Vec<
-        ::prost::alloc::string::String,
-    >,
+    pub authorized_gae_applications: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// The tier (or machine type) for this instance, for example
     /// `db-custom-1-3840`. WARNING: Changing this restarts the instance.
     #[prost(string, tag = "3")]
@@ -1227,10 +1169,8 @@ pub struct Settings {
     /// User-provided labels, represented as a dictionary where each label is a
     /// single key value pair.
     #[prost(map = "string, string", tag = "5")]
-    pub user_labels: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub user_labels:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// Availability type. Potential values:
     ///
     /// * `ZONAL`: The instance serves data from only one zone. Outages in that
@@ -1358,17 +1298,7 @@ pub struct Settings {
 /// Nested message and enum types in `Settings`.
 pub mod settings {
     /// Specifies when the instance is activated.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum SqlActivationPolicy {
         /// Unknown activation plan.
@@ -1405,17 +1335,7 @@ pub mod settings {
         }
     }
     /// The edition of the instance, can be ENTERPRISE or ENTERPRISE_PLUS.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Edition {
         /// The instance did not specify the edition.
@@ -1448,17 +1368,7 @@ pub mod settings {
         }
     }
     /// The options for enforcing Cloud SQL connectors in the instance.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum ConnectorEnforcement {
         /// The requirement for Cloud SQL connectors is unknown.
@@ -2179,7 +2089,7 @@ pub struct SqlInstancesInsertRequest {
     #[prost(string, tag = "1")]
     pub project: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "100")]
-    pub body: ::core::option::Option<DatabaseInstance>,
+    pub body: ::core::option::Option<DatabaseMetrics>,
 }
 /// Instance list request.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2232,7 +2142,7 @@ pub struct SqlInstancesPatchRequest {
     #[prost(string, tag = "2")]
     pub project: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "100")]
-    pub body: ::core::option::Option<DatabaseInstance>,
+    pub body: ::core::option::Option<DatabaseMetrics>,
 }
 /// Instance promote replica request.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2353,7 +2263,7 @@ pub struct SqlInstancesUpdateRequest {
     #[prost(string, tag = "2")]
     pub project: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "100")]
-    pub body: ::core::option::Option<DatabaseInstance>,
+    pub body: ::core::option::Option<DatabaseMetrics>,
 }
 /// Instance reschedule maintenance request.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2398,23 +2308,17 @@ pub struct BackupReencryptionConfig {
     #[prost(int32, optional, tag = "1")]
     pub backup_limit: ::core::option::Option<i32>,
     /// Type of backups users want to re-encrypt.
-    #[prost(enumeration = "backup_reencryption_config::BackupType", optional, tag = "2")]
+    #[prost(
+        enumeration = "backup_reencryption_config::BackupType",
+        optional,
+        tag = "2"
+    )]
     pub backup_type: ::core::option::Option<i32>,
 }
 /// Nested message and enum types in `BackupReencryptionConfig`.
 pub mod backup_reencryption_config {
     /// Backup type for re-encryption
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum BackupType {
         /// Unknown backup type, will be defaulted to AUTOMATIC backup type
@@ -2484,23 +2388,12 @@ pub struct SqlInstancesVerifyExternalSyncSettingsRequest {
         oneof = "sql_instances_verify_external_sync_settings_request::SyncConfig",
         tags = "6"
     )]
-    pub sync_config: ::core::option::Option<
-        sql_instances_verify_external_sync_settings_request::SyncConfig,
-    >,
+    pub sync_config:
+        ::core::option::Option<sql_instances_verify_external_sync_settings_request::SyncConfig>,
 }
 /// Nested message and enum types in `SqlInstancesVerifyExternalSyncSettingsRequest`.
 pub mod sql_instances_verify_external_sync_settings_request {
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum ExternalSyncMode {
         /// Unknown external sync mode, will be defaulted to ONLINE mode
@@ -2568,25 +2461,16 @@ pub struct SqlInstancesStartExternalSyncRequest {
         tag = "7"
     )]
     pub sync_parallel_level: i32,
-    #[prost(oneof = "sql_instances_start_external_sync_request::SyncConfig", tags = "6")]
-    pub sync_config: ::core::option::Option<
-        sql_instances_start_external_sync_request::SyncConfig,
-    >,
+    #[prost(
+        oneof = "sql_instances_start_external_sync_request::SyncConfig",
+        tags = "6"
+    )]
+    pub sync_config: ::core::option::Option<sql_instances_start_external_sync_request::SyncConfig>,
 }
 /// Nested message and enum types in `SqlInstancesStartExternalSyncRequest`.
 pub mod sql_instances_start_external_sync_request {
     /// External Sync parallel level.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum ExternalSyncParallelLevel {
         /// Unknown sync parallel level. Will be defaulted to OPTIMAL.
@@ -2719,7 +2603,7 @@ pub struct InstancesListResponse {
     pub warnings: ::prost::alloc::vec::Vec<ApiWarning>,
     /// List of database instance resources.
     #[prost(message, repeated, tag = "3")]
-    pub items: ::prost::alloc::vec::Vec<DatabaseInstance>,
+    pub items: ::prost::alloc::vec::Vec<DatabaseMetrics>,
     /// The continuation token, used to page through large result sets. Provide
     /// this value in a subsequent request to return the next page of results.
     #[prost(string, tag = "4")]
@@ -2843,7 +2727,7 @@ pub struct BinLogCoordinates {
 /// A Cloud SQL instance resource.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DatabaseInstance {
+pub struct DatabaseMetrics {
     /// This is always `sql#instance`.
     #[prost(string, tag = "1")]
     pub kind: ::prost::alloc::string::String,
@@ -2957,9 +2841,7 @@ pub struct DatabaseInstance {
     pub secondary_gce_zone: ::prost::alloc::string::String,
     /// Disk encryption configuration specific to an instance.
     #[prost(message, optional, tag = "26")]
-    pub disk_encryption_configuration: ::core::option::Option<
-        DiskEncryptionConfiguration,
-    >,
+    pub disk_encryption_configuration: ::core::option::Option<DiskEncryptionConfiguration>,
     /// Disk encryption status specific to an instance.
     #[prost(message, optional, tag = "27")]
     pub disk_encryption_status: ::core::option::Option<DiskEncryptionStatus>,
@@ -2969,9 +2851,7 @@ pub struct DatabaseInstance {
     pub root_password: ::prost::alloc::string::String,
     /// The start time of any upcoming scheduled maintenance for this instance.
     #[prost(message, optional, tag = "30")]
-    pub scheduled_maintenance: ::core::option::Option<
-        database_instance::SqlScheduledMaintenance,
-    >,
+    pub scheduled_maintenance: ::core::option::Option<database_instance::SqlScheduledMaintenance>,
     /// The status indicating if instance satisfiesPzs.
     /// Reserved for future use.
     #[prost(message, optional, tag = "35")]
@@ -2988,9 +2868,7 @@ pub struct DatabaseInstance {
     /// * Readers:
     /// * the proactive database wellness job
     #[prost(message, optional, tag = "38")]
-    pub out_of_disk_report: ::core::option::Option<
-        database_instance::SqlOutOfDiskReport,
-    >,
+    pub out_of_disk_report: ::core::option::Option<database_instance::SqlOutOfDiskReport>,
     /// Output only. The time when the instance was created in
     /// [RFC 3339](<https://tools.ietf.org/html/rfc3339>) format, for example
     /// `2012-11-15T16:19:00.094Z`.
@@ -2998,14 +2876,12 @@ pub struct DatabaseInstance {
     pub create_time: ::core::option::Option<::prost_types::Timestamp>,
     /// Output only. List all maintenance versions applicable on the instance
     #[prost(string, repeated, tag = "41")]
-    pub available_maintenance_versions: ::prost::alloc::vec::Vec<
-        ::prost::alloc::string::String,
-    >,
+    pub available_maintenance_versions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// The current software version on the instance.
     #[prost(string, tag = "42")]
     pub maintenance_version: ::prost::alloc::string::String,
 }
-/// Nested message and enum types in `DatabaseInstance`.
+/// Nested message and enum types in `DatabaseMetrics`.
 pub mod database_instance {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -3068,15 +2944,7 @@ pub mod database_instance {
     pub mod sql_out_of_disk_report {
         /// This enum lists all possible states regarding out-of-disk issues.
         #[derive(
-            Clone,
-            Copy,
-            Debug,
-            PartialEq,
-            Eq,
-            Hash,
-            PartialOrd,
-            Ord,
-            ::prost::Enumeration
+            Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration,
         )]
         #[repr(i32)]
         pub enum SqlOutOfDiskState {
@@ -3112,17 +2980,7 @@ pub mod database_instance {
         }
     }
     /// The current serving state of the database instance.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum SqlInstanceState {
         /// The state of the instance is unknown.
@@ -3182,9 +3040,8 @@ pub mod database_instance {
 pub struct SqlInstancesRescheduleMaintenanceRequestBody {
     /// Required. The type of the reschedule the user wants.
     #[prost(message, optional, tag = "3")]
-    pub reschedule: ::core::option::Option<
-        sql_instances_reschedule_maintenance_request_body::Reschedule,
-    >,
+    pub reschedule:
+        ::core::option::Option<sql_instances_reschedule_maintenance_request_body::Reschedule>,
 }
 /// Nested message and enum types in `SqlInstancesRescheduleMaintenanceRequestBody`.
 pub mod sql_instances_reschedule_maintenance_request_body {
@@ -3201,17 +3058,7 @@ pub mod sql_instances_reschedule_maintenance_request_body {
         #[prost(message, optional, tag = "2")]
         pub schedule_time: ::core::option::Option<::prost_types::Timestamp>,
     }
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum RescheduleType {
         Unspecified = 0,
@@ -3350,17 +3197,7 @@ pub struct SqlExternalSyncSettingError {
 }
 /// Nested message and enum types in `SqlExternalSyncSettingError`.
 pub mod sql_external_sync_setting_error {
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum SqlExternalSyncSettingErrorType {
         Unspecified = 0,
@@ -3443,25 +3280,17 @@ pub mod sql_external_sync_setting_error {
                 SqlExternalSyncSettingErrorType::Unspecified => {
                     "SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED"
                 }
-                SqlExternalSyncSettingErrorType::ConnectionFailure => {
-                    "CONNECTION_FAILURE"
-                }
+                SqlExternalSyncSettingErrorType::ConnectionFailure => "CONNECTION_FAILURE",
                 SqlExternalSyncSettingErrorType::BinlogNotEnabled => "BINLOG_NOT_ENABLED",
                 SqlExternalSyncSettingErrorType::IncompatibleDatabaseVersion => {
                     "INCOMPATIBLE_DATABASE_VERSION"
                 }
-                SqlExternalSyncSettingErrorType::ReplicaAlreadySetup => {
-                    "REPLICA_ALREADY_SETUP"
-                }
-                SqlExternalSyncSettingErrorType::InsufficientPrivilege => {
-                    "INSUFFICIENT_PRIVILEGE"
-                }
+                SqlExternalSyncSettingErrorType::ReplicaAlreadySetup => "REPLICA_ALREADY_SETUP",
+                SqlExternalSyncSettingErrorType::InsufficientPrivilege => "INSUFFICIENT_PRIVILEGE",
                 SqlExternalSyncSettingErrorType::UnsupportedMigrationType => {
                     "UNSUPPORTED_MIGRATION_TYPE"
                 }
-                SqlExternalSyncSettingErrorType::NoPglogicalInstalled => {
-                    "NO_PGLOGICAL_INSTALLED"
-                }
+                SqlExternalSyncSettingErrorType::NoPglogicalInstalled => "NO_PGLOGICAL_INSTALLED",
                 SqlExternalSyncSettingErrorType::PglogicalNodeAlreadyExists => {
                     "PGLOGICAL_NODE_ALREADY_EXISTS"
                 }
@@ -3478,34 +3307,24 @@ pub mod sql_external_sync_setting_error {
                 SqlExternalSyncSettingErrorType::InsufficientMaxWorkerProcesses => {
                     "INSUFFICIENT_MAX_WORKER_PROCESSES"
                 }
-                SqlExternalSyncSettingErrorType::UnsupportedExtensions => {
-                    "UNSUPPORTED_EXTENSIONS"
-                }
+                SqlExternalSyncSettingErrorType::UnsupportedExtensions => "UNSUPPORTED_EXTENSIONS",
                 SqlExternalSyncSettingErrorType::InvalidRdsLogicalReplication => {
                     "INVALID_RDS_LOGICAL_REPLICATION"
                 }
-                SqlExternalSyncSettingErrorType::InvalidLoggingSetup => {
-                    "INVALID_LOGGING_SETUP"
-                }
+                SqlExternalSyncSettingErrorType::InvalidLoggingSetup => "INVALID_LOGGING_SETUP",
                 SqlExternalSyncSettingErrorType::InvalidDbParam => "INVALID_DB_PARAM",
-                SqlExternalSyncSettingErrorType::UnsupportedGtidMode => {
-                    "UNSUPPORTED_GTID_MODE"
-                }
+                SqlExternalSyncSettingErrorType::UnsupportedGtidMode => "UNSUPPORTED_GTID_MODE",
                 SqlExternalSyncSettingErrorType::SqlserverAgentNotRunning => {
                     "SQLSERVER_AGENT_NOT_RUNNING"
                 }
                 SqlExternalSyncSettingErrorType::UnsupportedTableDefinition => {
                     "UNSUPPORTED_TABLE_DEFINITION"
                 }
-                SqlExternalSyncSettingErrorType::UnsupportedDefiner => {
-                    "UNSUPPORTED_DEFINER"
-                }
+                SqlExternalSyncSettingErrorType::UnsupportedDefiner => "UNSUPPORTED_DEFINER",
                 SqlExternalSyncSettingErrorType::SqlserverServernameMismatch => {
                     "SQLSERVER_SERVERNAME_MISMATCH"
                 }
-                SqlExternalSyncSettingErrorType::PrimaryAlreadySetup => {
-                    "PRIMARY_ALREADY_SETUP"
-                }
+                SqlExternalSyncSettingErrorType::PrimaryAlreadySetup => "PRIMARY_ALREADY_SETUP",
                 SqlExternalSyncSettingErrorType::UnsupportedBinlogFormat => {
                     "UNSUPPORTED_BINLOG_FORMAT"
                 }
@@ -3515,9 +3334,7 @@ pub mod sql_external_sync_setting_error {
                 SqlExternalSyncSettingErrorType::UnsupportedStorageEngine => {
                     "UNSUPPORTED_STORAGE_ENGINE"
                 }
-                SqlExternalSyncSettingErrorType::LimitedSupportTables => {
-                    "LIMITED_SUPPORT_TABLES"
-                }
+                SqlExternalSyncSettingErrorType::LimitedSupportTables => "LIMITED_SUPPORT_TABLES",
                 SqlExternalSyncSettingErrorType::ExistingDataInReplica => {
                     "EXISTING_DATA_IN_REPLICA"
                 }
@@ -3539,43 +3356,29 @@ pub mod sql_external_sync_setting_error {
         /// Creates an enum from field names used in the ProtoBuf definition.
         pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
             match value {
-                "SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED" => {
-                    Some(Self::Unspecified)
-                }
+                "SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
                 "CONNECTION_FAILURE" => Some(Self::ConnectionFailure),
                 "BINLOG_NOT_ENABLED" => Some(Self::BinlogNotEnabled),
-                "INCOMPATIBLE_DATABASE_VERSION" => {
-                    Some(Self::IncompatibleDatabaseVersion)
-                }
+                "INCOMPATIBLE_DATABASE_VERSION" => Some(Self::IncompatibleDatabaseVersion),
                 "REPLICA_ALREADY_SETUP" => Some(Self::ReplicaAlreadySetup),
                 "INSUFFICIENT_PRIVILEGE" => Some(Self::InsufficientPrivilege),
                 "UNSUPPORTED_MIGRATION_TYPE" => Some(Self::UnsupportedMigrationType),
                 "NO_PGLOGICAL_INSTALLED" => Some(Self::NoPglogicalInstalled),
                 "PGLOGICAL_NODE_ALREADY_EXISTS" => Some(Self::PglogicalNodeAlreadyExists),
                 "INVALID_WAL_LEVEL" => Some(Self::InvalidWalLevel),
-                "INVALID_SHARED_PRELOAD_LIBRARY" => {
-                    Some(Self::InvalidSharedPreloadLibrary)
-                }
-                "INSUFFICIENT_MAX_REPLICATION_SLOTS" => {
-                    Some(Self::InsufficientMaxReplicationSlots)
-                }
+                "INVALID_SHARED_PRELOAD_LIBRARY" => Some(Self::InvalidSharedPreloadLibrary),
+                "INSUFFICIENT_MAX_REPLICATION_SLOTS" => Some(Self::InsufficientMaxReplicationSlots),
                 "INSUFFICIENT_MAX_WAL_SENDERS" => Some(Self::InsufficientMaxWalSenders),
-                "INSUFFICIENT_MAX_WORKER_PROCESSES" => {
-                    Some(Self::InsufficientMaxWorkerProcesses)
-                }
+                "INSUFFICIENT_MAX_WORKER_PROCESSES" => Some(Self::InsufficientMaxWorkerProcesses),
                 "UNSUPPORTED_EXTENSIONS" => Some(Self::UnsupportedExtensions),
-                "INVALID_RDS_LOGICAL_REPLICATION" => {
-                    Some(Self::InvalidRdsLogicalReplication)
-                }
+                "INVALID_RDS_LOGICAL_REPLICATION" => Some(Self::InvalidRdsLogicalReplication),
                 "INVALID_LOGGING_SETUP" => Some(Self::InvalidLoggingSetup),
                 "INVALID_DB_PARAM" => Some(Self::InvalidDbParam),
                 "UNSUPPORTED_GTID_MODE" => Some(Self::UnsupportedGtidMode),
                 "SQLSERVER_AGENT_NOT_RUNNING" => Some(Self::SqlserverAgentNotRunning),
                 "UNSUPPORTED_TABLE_DEFINITION" => Some(Self::UnsupportedTableDefinition),
                 "UNSUPPORTED_DEFINER" => Some(Self::UnsupportedDefiner),
-                "SQLSERVER_SERVERNAME_MISMATCH" => {
-                    Some(Self::SqlserverServernameMismatch)
-                }
+                "SQLSERVER_SERVERNAME_MISMATCH" => Some(Self::SqlserverServernameMismatch),
                 "PRIMARY_ALREADY_SETUP" => Some(Self::PrimaryAlreadySetup),
                 "UNSUPPORTED_BINLOG_FORMAT" => Some(Self::UnsupportedBinlogFormat),
                 "BINLOG_RETENTION_SETTING" => Some(Self::BinlogRetentionSetting),
@@ -3586,9 +3389,7 @@ pub mod sql_external_sync_setting_error {
                 "RISKY_BACKUP_ADMIN_PRIVILEGE" => Some(Self::RiskyBackupAdminPrivilege),
                 "INSUFFICIENT_GCS_PERMISSIONS" => Some(Self::InsufficientGcsPermissions),
                 "INVALID_FILE_INFO" => Some(Self::InvalidFileInfo),
-                "UNSUPPORTED_DATABASE_SETTINGS" => {
-                    Some(Self::UnsupportedDatabaseSettings)
-                }
+                "UNSUPPORTED_DATABASE_SETTINGS" => Some(Self::UnsupportedDatabaseSettings),
                 _ => None,
             }
         }
@@ -3735,8 +3536,8 @@ impl SqlSuspensionReason {
 /// Generated client implementations.
 pub mod sql_instances_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     /// Service to manage Cloud SQL instances.
     #[derive(Debug, Clone)]
     pub struct SqlInstancesServiceClient<T> {
@@ -3781,9 +3582,8 @@ pub mod sql_instances_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             SqlInstancesServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -3827,27 +3627,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesAddServerCaRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/AddServerCa",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "AddServerCa",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "AddServerCa",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Creates a Cloud SQL instance as a clone of the source instance. Using this
@@ -3856,24 +3650,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesCloneRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/Clone",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("google.cloud.sql.v1.SqlInstancesService", "Clone"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "Clone",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Deletes a Cloud SQL instance.
@@ -3881,24 +3672,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesDeleteRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/Delete",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("google.cloud.sql.v1.SqlInstancesService", "Delete"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "Delete",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Demotes the stand-alone instance to be a Cloud SQL read replica for an
@@ -3907,27 +3695,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesDemoteMasterRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/DemoteMaster",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "DemoteMaster",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "DemoteMaster",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Exports data from a Cloud SQL instance to a Cloud Storage bucket as a SQL
@@ -3936,24 +3718,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesExportRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/Export",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("google.cloud.sql.v1.SqlInstancesService", "Export"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "Export",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Initiates a manual failover of a high availability (HA) primary instance
@@ -3968,27 +3747,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesFailoverRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/Failover",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "Failover",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "Failover",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Reencrypt CMEK instance with latest key version.
@@ -3996,55 +3769,43 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesReencryptRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/Reencrypt",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "Reencrypt",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "Reencrypt",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Retrieves a resource containing information about a Cloud SQL instance.
         pub async fn get(
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesGetRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::DatabaseInstance>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::DatabaseMetrics>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/Get",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("google.cloud.sql.v1.SqlInstancesService", "Get"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "Get",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Imports data into a Cloud SQL instance from a SQL dump  or CSV file in
@@ -4053,24 +3814,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesImportRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/Import",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("google.cloud.sql.v1.SqlInstancesService", "Import"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "Import",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Creates a new Cloud SQL instance.
@@ -4078,52 +3836,44 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesInsertRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/Insert",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("google.cloud.sql.v1.SqlInstancesService", "Insert"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "Insert",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Lists instances under a given project.
         pub async fn list(
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesListRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::InstancesListResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::InstancesListResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/List",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("google.cloud.sql.v1.SqlInstancesService", "List"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "List",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Lists all of the trusted Certificate Authorities (CAs) for the specified
@@ -4138,27 +3888,21 @@ pub mod sql_instances_service_client {
             tonic::Response<super::InstancesListServerCasResponse>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/ListServerCas",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "ListServerCas",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "ListServerCas",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Partially updates settings of a Cloud SQL instance by merging the request
@@ -4167,24 +3911,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesPatchRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/Patch",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("google.cloud.sql.v1.SqlInstancesService", "Patch"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "Patch",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Promotes the read replica instance to be a stand-alone Cloud SQL instance.
@@ -4193,27 +3934,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesPromoteReplicaRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/PromoteReplica",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "PromoteReplica",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "PromoteReplica",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Deletes all client certificates and generates a new server SSL certificate
@@ -4222,27 +3957,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesResetSslConfigRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/ResetSslConfig",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "ResetSslConfig",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "ResetSslConfig",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Restarts a Cloud SQL instance.
@@ -4250,24 +3979,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesRestartRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/Restart",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("google.cloud.sql.v1.SqlInstancesService", "Restart"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "Restart",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Restores a backup of a Cloud SQL instance. Using this operation might cause
@@ -4276,27 +4002,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesRestoreBackupRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/RestoreBackup",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "RestoreBackup",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "RestoreBackup",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Rotates the server certificate to one signed by the Certificate Authority
@@ -4305,27 +4025,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesRotateServerCaRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/RotateServerCa",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "RotateServerCa",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "RotateServerCa",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Starts the replication in the read replica instance.
@@ -4333,27 +4047,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesStartReplicaRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/StartReplica",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "StartReplica",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "StartReplica",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Stops the replication in the read replica instance.
@@ -4361,27 +4069,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesStopReplicaRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/StopReplica",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "StopReplica",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "StopReplica",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Truncate MySQL general and slow query log tables
@@ -4390,27 +4092,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesTruncateLogRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/TruncateLog",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "TruncateLog",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "TruncateLog",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Updates settings of a Cloud SQL instance. Using this operation might cause
@@ -4419,24 +4115,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesUpdateRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/Update",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("google.cloud.sql.v1.SqlInstancesService", "Update"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "Update",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Generates a short-lived X509 certificate containing the provided public key
@@ -4445,94 +4138,70 @@ pub mod sql_instances_service_client {
         /// database.
         pub async fn create_ephemeral(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::SqlInstancesCreateEphemeralCertRequest,
-            >,
+            request: impl tonic::IntoRequest<super::SqlInstancesCreateEphemeralCertRequest>,
         ) -> std::result::Result<tonic::Response<super::SslCert>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/CreateEphemeral",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "CreateEphemeral",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "CreateEphemeral",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Reschedules the maintenance on the given instance.
         pub async fn reschedule_maintenance(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::SqlInstancesRescheduleMaintenanceRequest,
-            >,
+            request: impl tonic::IntoRequest<super::SqlInstancesRescheduleMaintenanceRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/RescheduleMaintenance",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "RescheduleMaintenance",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "RescheduleMaintenance",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Verify External primary instance external sync settings.
         pub async fn verify_external_sync_settings(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::SqlInstancesVerifyExternalSyncSettingsRequest,
-            >,
+            request: impl tonic::IntoRequest<super::SqlInstancesVerifyExternalSyncSettingsRequest>,
         ) -> std::result::Result<
             tonic::Response<super::SqlInstancesVerifyExternalSyncSettingsResponse>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/VerifyExternalSyncSettings",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "VerifyExternalSyncSettings",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "VerifyExternalSyncSettings",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Start External primary instance migration.
@@ -4540,27 +4209,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesStartExternalSyncRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/StartExternalSync",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "StartExternalSync",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "StartExternalSync",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Perform Disk Shrink on primary instance.
@@ -4568,60 +4231,46 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesPerformDiskShrinkRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/PerformDiskShrink",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "PerformDiskShrink",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "PerformDiskShrink",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Get Disk Shrink Config for a given instance.
         pub async fn get_disk_shrink_config(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::SqlInstancesGetDiskShrinkConfigRequest,
-            >,
+            request: impl tonic::IntoRequest<super::SqlInstancesGetDiskShrinkConfigRequest>,
         ) -> std::result::Result<
             tonic::Response<super::SqlInstancesGetDiskShrinkConfigResponse>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/GetDiskShrinkConfig",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "GetDiskShrinkConfig",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "GetDiskShrinkConfig",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Reset Replica Size to primary instance disk size.
@@ -4629,27 +4278,21 @@ pub mod sql_instances_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SqlInstancesResetReplicaSizeRequest>,
         ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.sql.v1.SqlInstancesService/ResetReplicaSize",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "ResetReplicaSize",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.sql.v1.SqlInstancesService",
+                "ResetReplicaSize",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }

--- a/sdk/src/services/gcloud/api/google.cloud.sql.v1.rs
+++ b/sdk/src/services/gcloud/api/google.cloud.sql.v1.rs
@@ -54,12 +54,6 @@ pub mod api_warning {
         /// Warning when user provided maxResults parameter exceeds the limit.  The
         /// returned result set may be incomplete.
         MaxResultsExceedsLimit = 2,
-        /// Warning when user tries to create/update a user with credentials that
-        /// have previously been compromised by a public data breach.
-        CompromisedCredentials = 3,
-        /// Warning when the operation succeeds but some non-critical workflow state
-        /// failed.
-        InternalStateFailure = 4,
     }
     impl SqlApiWarningCode {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -71,8 +65,6 @@ pub mod api_warning {
                 SqlApiWarningCode::Unspecified => "SQL_API_WARNING_CODE_UNSPECIFIED",
                 SqlApiWarningCode::RegionUnreachable => "REGION_UNREACHABLE",
                 SqlApiWarningCode::MaxResultsExceedsLimit => "MAX_RESULTS_EXCEEDS_LIMIT",
-                SqlApiWarningCode::CompromisedCredentials => "COMPROMISED_CREDENTIALS",
-                SqlApiWarningCode::InternalStateFailure => "INTERNAL_STATE_FAILURE",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -81,8 +73,6 @@ pub mod api_warning {
                 "SQL_API_WARNING_CODE_UNSPECIFIED" => Some(Self::Unspecified),
                 "REGION_UNREACHABLE" => Some(Self::RegionUnreachable),
                 "MAX_RESULTS_EXCEEDS_LIMIT" => Some(Self::MaxResultsExceedsLimit),
-                "COMPROMISED_CREDENTIALS" => Some(Self::CompromisedCredentials),
-                "INTERNAL_STATE_FAILURE" => Some(Self::InternalStateFailure),
                 _ => None,
             }
         }
@@ -560,17 +550,6 @@ pub mod import_context {
         /// Type of the bak content, FULL or DIFF
         #[prost(enumeration = "super::BakType", tag = "6")]
         pub bak_type: i32,
-        /// Optional. The timestamp when the import should stop. This timestamp is in
-        /// the [RFC 3339](<https://tools.ietf.org/html/rfc3339>) format (for example,
-        /// `2023-10-01T16:19:00.094`). This field is equivalent to the STOPAT
-        /// keyword and applies to Cloud SQL for SQL Server only.
-        #[prost(message, optional, tag = "7")]
-        pub stop_at: ::core::option::Option<::prost_types::Timestamp>,
-        /// Optional. The marked transaction where the import should stop. This field
-        /// is equivalent to the STOPATMARK keyword and applies to Cloud SQL for SQL
-        /// Server only.
-        #[prost(string, tag = "8")]
-        pub stop_at_mark: ::prost::alloc::string::String,
     }
     /// Nested message and enum types in `SqlBakImportOptions`.
     pub mod sql_bak_import_options {
@@ -606,15 +585,7 @@ pub struct IpConfiguration {
     /// be updated, but it cannot be removed after it is set.
     #[prost(string, tag = "2")]
     pub private_network: ::prost::alloc::string::String,
-    /// Use `ssl_mode` instead for MySQL and PostgreSQL. SQL Server uses this flag.
-    ///
-    /// Whether SSL/TLS connections over IP are enforced.
-    /// If set to false, then allow both non-SSL/non-TLS and SSL/TLS connections.
-    /// For SSL/TLS connections, the client certificate won't be verified. If
-    /// set to true, then only allow connections encrypted with SSL/TLS and with
-    /// valid client certificates. If you want to enforce SSL/TLS without enforcing
-    /// the requirement for valid client certificates, then use the `ssl_mode` flag
-    /// instead of the `require_ssl` flag.
+    /// Whether SSL connections over IP are enforced or not.
     #[prost(message, optional, tag = "3")]
     pub require_ssl: ::core::option::Option<bool>,
     /// The list of external networks that are allowed to connect to the instance
@@ -634,112 +605,6 @@ pub struct IpConfiguration {
     /// such as BigQuery.
     #[prost(message, optional, tag = "7")]
     pub enable_private_path_for_google_cloud_services: ::core::option::Option<bool>,
-    /// Specify how SSL/TLS is enforced in database connections. MySQL and
-    /// PostgreSQL use the `ssl_mode` flag. If you must use the `require_ssl` flag
-    /// for backward compatibility, then only the following value pairs are valid:
-    ///
-    /// * `ssl_mode=ALLOW_UNENCRYPTED_AND_ENCRYPTED` and `require_ssl=false`
-    /// * `ssl_mode=ENCRYPTED_ONLY` and `require_ssl=false`
-    /// * `ssl_mode=TRUSTED_CLIENT_CERTIFICATE_REQUIRED` and `require_ssl=true`
-    ///
-    /// The value of `ssl_mode` gets priority over the value of `require_ssl`. For
-    /// example, for the pair `ssl_mode=ENCRYPTED_ONLY` and `require_ssl=false`,
-    /// the `ssl_mode=ENCRYPTED_ONLY` means only accept SSL connections, while the
-    /// `require_ssl=false` means accept both non-SSL and SSL connections. MySQL
-    /// and PostgreSQL databases respect `ssl_mode` in this case and accept only
-    /// SSL connections.
-    ///
-    /// SQL Server uses the `require_ssl` flag. You can set the value for this flag
-    /// to `true` or `false`.
-    #[prost(enumeration = "ip_configuration::SslMode", tag = "8")]
-    pub ssl_mode: i32,
-    /// PSC settings for this instance.
-    #[prost(message, optional, tag = "9")]
-    pub psc_config: ::core::option::Option<PscConfig>,
-}
-/// Nested message and enum types in `IpConfiguration`.
-pub mod ip_configuration {
-    /// The SSL options for database connections.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
-    #[repr(i32)]
-    pub enum SslMode {
-        /// The SSL mode is unknown.
-        Unspecified = 0,
-        /// Allow non-SSL/non-TLS and SSL/TLS connections. For SSL/TLS connections,
-        /// the client certificate won't be verified.
-        /// When this value is used, the legacy `require_ssl` flag must be false or
-        /// cleared to avoid the conflict between values of two flags.
-        AllowUnencryptedAndEncrypted = 1,
-        /// Only allow connections encrypted with SSL/TLS.
-        /// When this value is used, the legacy `require_ssl` flag must be false or
-        /// cleared to avoid the conflict between values of two flags.
-        EncryptedOnly = 2,
-        /// Only allow connections encrypted with SSL/TLS and with valid
-        /// client certificates.
-        /// When this value is used, the legacy `require_ssl` flag must be true or
-        /// cleared to avoid the conflict between values of two flags.
-        TrustedClientCertificateRequired = 3,
-    }
-    impl SslMode {
-        /// String value of the enum field names used in the ProtoBuf definition.
-        ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn as_str_name(&self) -> &'static str {
-            match self {
-                SslMode::Unspecified => "SSL_MODE_UNSPECIFIED",
-                SslMode::AllowUnencryptedAndEncrypted => {
-                    "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
-                }
-                SslMode::EncryptedOnly => "ENCRYPTED_ONLY",
-                SslMode::TrustedClientCertificateRequired => {
-                    "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
-                }
-            }
-        }
-        /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-            match value {
-                "SSL_MODE_UNSPECIFIED" => Some(Self::Unspecified),
-                "ALLOW_UNENCRYPTED_AND_ENCRYPTED" => {
-                    Some(Self::AllowUnencryptedAndEncrypted)
-                }
-                "ENCRYPTED_ONLY" => Some(Self::EncryptedOnly),
-                "TRUSTED_CLIENT_CERTIFICATE_REQUIRED" => {
-                    Some(Self::TrustedClientCertificateRequired)
-                }
-                _ => None,
-            }
-        }
-    }
-}
-/// PSC settings for a Cloud SQL instance.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PscConfig {
-    /// Whether PSC connectivity is enabled for this instance.
-    #[prost(bool, optional, tag = "1")]
-    pub psc_enabled: ::core::option::Option<bool>,
-    /// Optional. The list of consumer projects that are allow-listed for PSC
-    /// connections to this instance. This instance can be connected to with PSC
-    /// from any network in these projects.
-    ///
-    /// Each consumer project in this list may be represented by a project number
-    /// (numeric) or by a project id (alphanumeric).
-    #[prost(string, repeated, tag = "2")]
-    pub allowed_consumer_projects: ::prost::alloc::vec::Vec<
-        ::prost::alloc::string::String,
-    >,
 }
 /// Preferred location. This specifies where a Cloud SQL instance is located.
 /// Note that if the preferred location is not available, the instance will be
@@ -759,7 +624,6 @@ pub struct LocationPreference {
     pub zone: ::prost::alloc::string::String,
     /// The preferred Compute Engine zone for the secondary/failover
     /// (for example: us-central1-a, us-central1-b, etc.).
-    /// To disable this field, set it to 'no_secondary_zone'.
     #[prost(string, tag = "4")]
     pub secondary_zone: ::prost::alloc::string::String,
     /// This is always `sql#locationPreference`.
@@ -901,7 +765,7 @@ pub struct DiskEncryptionStatus {
     #[prost(string, tag = "2")]
     pub kind: ::prost::alloc::string::String,
 }
-/// Database instance IP mapping
+/// Database instance IP Mapping.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpMapping {
@@ -957,9 +821,6 @@ pub struct Operation {
     /// populated.
     #[prost(message, optional, tag = "8")]
     pub error: ::core::option::Option<OperationErrors>,
-    /// An Admin API warning message.
-    #[prost(message, optional, tag = "19")]
-    pub api_warning: ::core::option::Option<ApiWarning>,
     /// The type of the operation. Valid values are:
     ///
     /// * `CREATE`
@@ -1287,10 +1148,6 @@ pub struct PasswordValidationPolicy {
     /// Whether the password policy is enabled or not.
     #[prost(message, optional, tag = "6")]
     pub enable_password_policy: ::core::option::Option<bool>,
-    /// Disallow credentials that have been previously compromised by a public data
-    /// breach.
-    #[prost(message, optional, tag = "7")]
-    pub disallow_compromised_credentials: ::core::option::Option<bool>,
 }
 /// Nested message and enum types in `PasswordValidationPolicy`.
 pub mod password_validation_policy {
@@ -1758,14 +1615,12 @@ impl SqlFileType {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum BakType {
-    /// Default type.
+    /// default type.
     Unspecified = 0,
     /// Full backup.
     Full = 1,
     /// Differential backup.
     Diff = 2,
-    /// Transaction Log backup
-    Tlog = 3,
 }
 impl BakType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1777,7 +1632,6 @@ impl BakType {
             BakType::Unspecified => "BAK_TYPE_UNSPECIFIED",
             BakType::Full => "FULL",
             BakType::Diff => "DIFF",
-            BakType::Tlog => "TLOG",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1786,7 +1640,6 @@ impl BakType {
             "BAK_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
             "FULL" => Some(Self::Full),
             "DIFF" => Some(Self::Diff),
-            "TLOG" => Some(Self::Tlog),
             _ => None,
         }
     }
@@ -2195,11 +2048,6 @@ pub enum SqlUpdateTrack {
     /// your instance prefer to let Cloud SQL choose the timing of restart (within
     /// its Maintenance window, if applicable).
     Stable = 2,
-    /// For instance update that requires a restart, this update track indicates
-    /// your instance prefer to let Cloud SQL choose the timing of restart (within
-    /// its Maintenance window, if applicable) to be at least 5 weeks after the
-    /// notification.
-    Week5 = 3,
 }
 impl SqlUpdateTrack {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2211,7 +2059,6 @@ impl SqlUpdateTrack {
             SqlUpdateTrack::Unspecified => "SQL_UPDATE_TRACK_UNSPECIFIED",
             SqlUpdateTrack::Canary => "canary",
             SqlUpdateTrack::Stable => "stable",
-            SqlUpdateTrack::Week5 => "week5",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2220,7 +2067,6 @@ impl SqlUpdateTrack {
             "SQL_UPDATE_TRACK_UNSPECIFIED" => Some(Self::Unspecified),
             "canary" => Some(Self::Canary),
             "stable" => Some(Self::Stable),
-            "week5" => Some(Self::Week5),
             _ => None,
         }
     }
@@ -2273,20 +2119,6 @@ pub struct SqlInstancesDemoteMasterRequest {
     pub project: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "100")]
     pub body: ::core::option::Option<InstancesDemoteMasterRequest>,
-}
-/// Instance demote request.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SqlInstancesDemoteRequest {
-    /// Required. Cloud SQL instance name.
-    #[prost(string, tag = "1")]
-    pub instance: ::prost::alloc::string::String,
-    /// Required. ID of the project that contains the instance.
-    #[prost(string, tag = "2")]
-    pub project: ::prost::alloc::string::String,
-    /// Required. The request body.
-    #[prost(message, optional, tag = "100")]
-    pub body: ::core::option::Option<InstancesDemoteRequest>,
 }
 /// Instance export request.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2412,27 +2244,6 @@ pub struct SqlInstancesPromoteReplicaRequest {
     /// ID of the project that contains the read replica.
     #[prost(string, tag = "2")]
     pub project: ::prost::alloc::string::String,
-    /// Set to true if the promote operation should attempt to re-add the original
-    /// primary as a replica when it comes back online. Otherwise, if this value is
-    /// false or not set, the original primary will be a standalone instance.
-    #[prost(bool, tag = "3")]
-    pub failover: bool,
-}
-/// Instance switchover request.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SqlInstancesSwitchoverRequest {
-    /// Cloud SQL read replica instance name.
-    #[prost(string, tag = "1")]
-    pub instance: ::prost::alloc::string::String,
-    /// ID of the project that contains the replica.
-    #[prost(string, tag = "2")]
-    pub project: ::prost::alloc::string::String,
-    /// Optional. (MySQL only) Cloud SQL instance operations timeout, which is a
-    /// sum of all database operations. Default value is 10 minutes and can be
-    /// modified to a maximum value of 24 hours.
-    #[prost(message, optional, tag = "3")]
-    pub db_timeout: ::core::option::Option<::prost_types::Duration>,
 }
 /// Instance reset SSL config request.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2752,7 +2563,10 @@ pub struct SqlInstancesStartExternalSyncRequest {
     pub skip_verification: bool,
     /// Optional. Parallel level for initial data sync. Currently only applicable
     /// for MySQL.
-    #[prost(enumeration = "ExternalSyncParallelLevel", tag = "7")]
+    #[prost(
+        enumeration = "sql_instances_start_external_sync_request::ExternalSyncParallelLevel",
+        tag = "7"
+    )]
     pub sync_parallel_level: i32,
     #[prost(oneof = "sql_instances_start_external_sync_request::SyncConfig", tags = "6")]
     pub sync_config: ::core::option::Option<
@@ -2761,6 +2575,55 @@ pub struct SqlInstancesStartExternalSyncRequest {
 }
 /// Nested message and enum types in `SqlInstancesStartExternalSyncRequest`.
 pub mod sql_instances_start_external_sync_request {
+    /// External Sync parallel level.
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum ExternalSyncParallelLevel {
+        /// Unknown sync parallel level. Will be defaulted to OPTIMAL.
+        Unspecified = 0,
+        /// Minimal parallel level.
+        Min = 1,
+        /// Optimal parallel level.
+        Optimal = 2,
+        /// Maximum parallel level.
+        Max = 3,
+    }
+    impl ExternalSyncParallelLevel {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                ExternalSyncParallelLevel::Unspecified => {
+                    "EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED"
+                }
+                ExternalSyncParallelLevel::Min => "MIN",
+                ExternalSyncParallelLevel::Optimal => "OPTIMAL",
+                ExternalSyncParallelLevel::Max => "MAX",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED" => Some(Self::Unspecified),
+                "MIN" => Some(Self::Min),
+                "OPTIMAL" => Some(Self::Optimal),
+                "MAX" => Some(Self::Max),
+                _ => None,
+            }
+        }
+    }
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum SyncConfig {
@@ -2808,15 +2671,6 @@ pub struct InstancesDemoteMasterRequest {
     /// Contains details about the demoteMaster operation.
     #[prost(message, optional, tag = "1")]
     pub demote_master_context: ::core::option::Option<DemoteMasterContext>,
-}
-/// This request is used to demote an existing standalone instance to be a
-/// Cloud SQL read replica for an external database server.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InstancesDemoteRequest {
-    /// Required. Contains details about the demote operation.
-    #[prost(message, optional, tag = "1")]
-    pub demote_context: ::core::option::Option<DemoteContext>,
 }
 /// Database instance export request.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2936,28 +2790,6 @@ pub struct SqlInstancesGetDiskShrinkConfigResponse {
     #[prost(string, tag = "3")]
     pub message: ::prost::alloc::string::String,
 }
-/// Instance get latest recovery time request.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SqlInstancesGetLatestRecoveryTimeRequest {
-    /// Cloud SQL instance ID. This does not include the project ID.
-    #[prost(string, tag = "1")]
-    pub instance: ::prost::alloc::string::String,
-    /// Project ID of the project that contains the instance.
-    #[prost(string, tag = "2")]
-    pub project: ::prost::alloc::string::String,
-}
-/// Instance get latest recovery time response.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SqlInstancesGetLatestRecoveryTimeResponse {
-    /// This is always `sql#getLatestRecoveryTime`.
-    #[prost(string, tag = "1")]
-    pub kind: ::prost::alloc::string::String,
-    /// Timestamp, identifies the latest recovery time of the source instance.
-    #[prost(message, optional, tag = "2")]
-    pub latest_recovery_time: ::core::option::Option<::prost_types::Timestamp>,
-}
 /// Database instance clone context.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2993,11 +2825,6 @@ pub struct CloneContext {
     /// instance. Clone all databases if empty.
     #[prost(string, repeated, tag = "9")]
     pub database_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// Optional. (Point-in-time recovery for PostgreSQL only) Clone to an instance
-    /// in the specified zone. If no zone is specified, clone to the same zone as
-    /// the source instance.
-    #[prost(string, optional, tag = "10")]
-    pub preferred_zone: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Binary log coordinates.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3177,27 +3004,6 @@ pub struct DatabaseInstance {
     /// The current software version on the instance.
     #[prost(string, tag = "42")]
     pub maintenance_version: ::prost::alloc::string::String,
-    #[prost(
-        enumeration = "database_instance::SqlNetworkArchitecture",
-        optional,
-        tag = "47"
-    )]
-    pub sql_network_architecture: ::core::option::Option<i32>,
-    /// Output only. The link to service attachment of PSC instance.
-    #[prost(string, optional, tag = "48")]
-    pub psc_service_attachment_link: ::core::option::Option<
-        ::prost::alloc::string::String,
-    >,
-    /// Output only. The dns name of the instance.
-    #[prost(string, optional, tag = "49")]
-    pub dns_name: ::core::option::Option<::prost::alloc::string::String>,
-    /// Output only. DEPRECATED: please use write_endpoint instead.
-    #[deprecated]
-    #[prost(string, optional, tag = "51")]
-    pub primary_dns_name: ::core::option::Option<::prost::alloc::string::String>,
-    /// Output only. The dns name of the primary instance in a replication group.
-    #[prost(string, optional, tag = "52")]
-    pub write_endpoint: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Nested message and enum types in `DatabaseInstance`.
 pub mod database_instance {
@@ -3369,54 +3175,6 @@ pub mod database_instance {
             }
         }
     }
-    /// The current SQL network architecture for the instance.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
-    #[repr(i32)]
-    pub enum SqlNetworkArchitecture {
-        Unspecified = 0,
-        /// Instance is a Tenancy Unit (TU) instance.
-        NewNetworkArchitecture = 1,
-        /// Instance is an Umbrella instance.
-        OldNetworkArchitecture = 2,
-    }
-    impl SqlNetworkArchitecture {
-        /// String value of the enum field names used in the ProtoBuf definition.
-        ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn as_str_name(&self) -> &'static str {
-            match self {
-                SqlNetworkArchitecture::Unspecified => {
-                    "SQL_NETWORK_ARCHITECTURE_UNSPECIFIED"
-                }
-                SqlNetworkArchitecture::NewNetworkArchitecture => {
-                    "NEW_NETWORK_ARCHITECTURE"
-                }
-                SqlNetworkArchitecture::OldNetworkArchitecture => {
-                    "OLD_NETWORK_ARCHITECTURE"
-                }
-            }
-        }
-        /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-            match value {
-                "SQL_NETWORK_ARCHITECTURE_UNSPECIFIED" => Some(Self::Unspecified),
-                "NEW_NETWORK_ARCHITECTURE" => Some(Self::NewNetworkArchitecture),
-                "OLD_NETWORK_ARCHITECTURE" => Some(Self::OldNetworkArchitecture),
-                _ => None,
-            }
-        }
-    }
 }
 /// Reschedule options for maintenance windows.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3517,19 +3275,6 @@ pub struct DemoteMasterContext {
     /// Flag to skip replication setup on the instance.
     #[prost(bool, tag = "5")]
     pub skip_replication_setup: bool,
-}
-/// This context is used to demote an existing standalone instance to be
-/// a Cloud SQL read replica for an external database server.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DemoteContext {
-    /// This is always `sql#demoteContext`.
-    #[prost(string, tag = "1")]
-    pub kind: ::prost::alloc::string::String,
-    /// Required. The name of the instance which acts as the on-premises primary
-    /// instance in the replication setup.
-    #[prost(string, tag = "2")]
-    pub source_representative_instance_name: ::prost::alloc::string::String,
 }
 /// Database instance failover context.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3687,21 +3432,6 @@ pub mod sql_external_sync_setting_error {
         InvalidFileInfo = 32,
         /// The source instance has unsupported database settings for migration.
         UnsupportedDatabaseSettings = 33,
-        /// The replication user is missing parallel import specific privileges.
-        /// (e.g. LOCK TABLES) for MySQL.
-        MysqlParallelImportInsufficientPrivilege = 34,
-        /// The global variable local_infile is off on external server replica.
-        LocalInfileOff = 35,
-        /// This code instructs customers to turn on point-in-time recovery manually
-        /// for the instance after promoting the Cloud SQL for PostgreSQL instance.
-        TurnOnPitrAfterPromote = 36,
-        /// The minor version of replica database is incompatible with the source.
-        IncompatibleDatabaseMinorVersion = 37,
-        /// This warning message indicates that Cloud SQL uses the maximum number of
-        /// subscriptions to migrate data from the source to the destination.
-        SourceMaxSubscriptions = 38,
-        /// Unable to verify definers on the source for MySQL.
-        UnableToVerifyDefiners = 39,
     }
     impl SqlExternalSyncSettingErrorType {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -3804,22 +3534,6 @@ pub mod sql_external_sync_setting_error {
                 SqlExternalSyncSettingErrorType::UnsupportedDatabaseSettings => {
                     "UNSUPPORTED_DATABASE_SETTINGS"
                 }
-                SqlExternalSyncSettingErrorType::MysqlParallelImportInsufficientPrivilege => {
-                    "MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE"
-                }
-                SqlExternalSyncSettingErrorType::LocalInfileOff => "LOCAL_INFILE_OFF",
-                SqlExternalSyncSettingErrorType::TurnOnPitrAfterPromote => {
-                    "TURN_ON_PITR_AFTER_PROMOTE"
-                }
-                SqlExternalSyncSettingErrorType::IncompatibleDatabaseMinorVersion => {
-                    "INCOMPATIBLE_DATABASE_MINOR_VERSION"
-                }
-                SqlExternalSyncSettingErrorType::SourceMaxSubscriptions => {
-                    "SOURCE_MAX_SUBSCRIPTIONS"
-                }
-                SqlExternalSyncSettingErrorType::UnableToVerifyDefiners => {
-                    "UNABLE_TO_VERIFY_DEFINERS"
-                }
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -3875,16 +3589,6 @@ pub mod sql_external_sync_setting_error {
                 "UNSUPPORTED_DATABASE_SETTINGS" => {
                     Some(Self::UnsupportedDatabaseSettings)
                 }
-                "MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE" => {
-                    Some(Self::MysqlParallelImportInsufficientPrivilege)
-                }
-                "LOCAL_INFILE_OFF" => Some(Self::LocalInfileOff),
-                "TURN_ON_PITR_AFTER_PROMOTE" => Some(Self::TurnOnPitrAfterPromote),
-                "INCOMPATIBLE_DATABASE_MINOR_VERSION" => {
-                    Some(Self::IncompatibleDatabaseMinorVersion)
-                }
-                "SOURCE_MAX_SUBSCRIPTIONS" => Some(Self::SourceMaxSubscriptions),
-                "UNABLE_TO_VERIFY_DEFINERS" => Some(Self::UnableToVerifyDefiners),
                 _ => None,
             }
         }
@@ -3945,50 +3649,6 @@ pub struct ReplicaConfiguration {
     /// the replica has to be in different zone with the primary instance.
     #[prost(message, optional, tag = "3")]
     pub failover_target: ::core::option::Option<bool>,
-    /// Optional. Specifies if a SQL Server replica is a cascadable replica. A
-    /// cascadable replica is a SQL Server cross region replica that supports
-    /// replica(s) under it.
-    #[prost(message, optional, tag = "5")]
-    pub cascadable_replica: ::core::option::Option<bool>,
-}
-/// External Sync parallel level.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
-pub enum ExternalSyncParallelLevel {
-    /// Unknown sync parallel level. Will be defaulted to OPTIMAL.
-    Unspecified = 0,
-    /// Minimal parallel level.
-    Min = 1,
-    /// Optimal parallel level.
-    Optimal = 2,
-    /// Maximum parallel level.
-    Max = 3,
-}
-impl ExternalSyncParallelLevel {
-    /// String value of the enum field names used in the ProtoBuf definition.
-    ///
-    /// The values are not transformed in any way and thus are considered stable
-    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-    pub fn as_str_name(&self) -> &'static str {
-        match self {
-            ExternalSyncParallelLevel::Unspecified => {
-                "EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED"
-            }
-            ExternalSyncParallelLevel::Min => "MIN",
-            ExternalSyncParallelLevel::Optimal => "OPTIMAL",
-            ExternalSyncParallelLevel::Max => "MAX",
-        }
-    }
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED" => Some(Self::Unspecified),
-            "MIN" => Some(Self::Min),
-            "OPTIMAL" => Some(Self::Optimal),
-            "MAX" => Some(Self::Max),
-            _ => None,
-        }
-    }
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -4267,32 +3927,6 @@ pub mod sql_instances_service_client {
                         "google.cloud.sql.v1.SqlInstancesService",
                         "DemoteMaster",
                     ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        /// Demotes an existing standalone instance to be a Cloud SQL read replica
-        /// for an external database server.
-        pub async fn demote(
-            &mut self,
-            request: impl tonic::IntoRequest<super::SqlInstancesDemoteRequest>,
-        ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.cloud.sql.v1.SqlInstancesService/Demote",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("google.cloud.sql.v1.SqlInstancesService", "Demote"),
                 );
             self.inner.unary(req, path, codec).await
         }
@@ -4578,34 +4212,6 @@ pub mod sql_instances_service_client {
                     GrpcMethod::new(
                         "google.cloud.sql.v1.SqlInstancesService",
                         "PromoteReplica",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        /// Switches over from the primary instance to the replica instance.
-        pub async fn switchover(
-            &mut self,
-            request: impl tonic::IntoRequest<super::SqlInstancesSwitchoverRequest>,
-        ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.cloud.sql.v1.SqlInstancesService/Switchover",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "Switchover",
                     ),
                 );
             self.inner.unary(req, path, codec).await
@@ -5042,39 +4648,6 @@ pub mod sql_instances_service_client {
                     GrpcMethod::new(
                         "google.cloud.sql.v1.SqlInstancesService",
                         "ResetReplicaSize",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        /// Get Latest Recovery Time for a given instance.
-        pub async fn get_latest_recovery_time(
-            &mut self,
-            request: impl tonic::IntoRequest<
-                super::SqlInstancesGetLatestRecoveryTimeRequest,
-            >,
-        ) -> std::result::Result<
-            tonic::Response<super::SqlInstancesGetLatestRecoveryTimeResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.cloud.sql.v1.SqlInstancesService/GetLatestRecoveryTime",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.sql.v1.SqlInstancesService",
-                        "GetLatestRecoveryTime",
                     ),
                 );
             self.inner.unary(req, path, codec).await

--- a/sdk/src/services/gcloud/api/google.monitoring.v3.rs
+++ b/sdk/src/services/gcloud/api/google.monitoring.v3.rs
@@ -861,3 +861,791 @@ pub mod text_locator {
         pub column: i32,
     }
 }
+/// The `ListMonitoredResourceDescriptors` request.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListMonitoredResourceDescriptorsRequest {
+    /// Required. The \[project\](<https://cloud.google.com/monitoring/api/v3#project_name>) on
+    /// which to execute the request. The format is:
+    ///
+    /// ```text
+    /// projects/\[PROJECT_ID_OR_NUMBER\]
+    /// ```
+    #[prost(string, tag = "5")]
+    pub name: ::prost::alloc::string::String,
+    /// An optional \[filter\](<https://cloud.google.com/monitoring/api/v3/filters>)
+    /// describing the descriptors to be returned.  The filter can reference the
+    /// descriptor's type and labels. For example, the following filter returns
+    /// only Google Compute Engine descriptors that have an `id` label:
+    ///
+    /// ```text
+    /// resource.type = starts_with("gce_") AND resource.label:id
+    /// ```
+    #[prost(string, tag = "2")]
+    pub filter: ::prost::alloc::string::String,
+    /// A positive number that is the maximum number of results to return.
+    #[prost(int32, tag = "3")]
+    pub page_size: i32,
+    /// If this field is not empty then it must contain the `nextPageToken` value
+    /// returned by a previous call to this method.  Using this field causes the
+    /// method to return additional results from the previous method call.
+    #[prost(string, tag = "4")]
+    pub page_token: ::prost::alloc::string::String,
+}
+/// The `ListMonitoredResourceDescriptors` response.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListMonitoredResourceDescriptorsResponse {
+    /// The monitored resource descriptors that are available to this project
+    /// and that match `filter`, if present.
+    #[prost(message, repeated, tag = "1")]
+    pub resource_descriptors: ::prost::alloc::vec::Vec<
+        super::super::api::MonitoredResourceDescriptor,
+    >,
+    /// If there are more results than have been returned, then this field is set
+    /// to a non-empty value.  To see the additional results,
+    /// use that value as `page_token` in the next call to this method.
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+}
+/// The `GetMonitoredResourceDescriptor` request.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetMonitoredResourceDescriptorRequest {
+    /// Required. The monitored resource descriptor to get.  The format is:
+    ///
+    /// ```text
+    /// projects/\[PROJECT_ID_OR_NUMBER]/monitoredResourceDescriptors/[RESOURCE_TYPE\]
+    /// ```
+    ///
+    /// The `\[RESOURCE_TYPE\]` is a predefined type, such as
+    /// `cloudsql_database`.
+    #[prost(string, tag = "3")]
+    pub name: ::prost::alloc::string::String,
+}
+/// The `ListMetricDescriptors` request.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListMetricDescriptorsRequest {
+    /// Required. The \[project\](<https://cloud.google.com/monitoring/api/v3#project_name>) on
+    /// which to execute the request. The format is:
+    ///
+    /// ```text
+    /// projects/\[PROJECT_ID_OR_NUMBER\]
+    /// ```
+    #[prost(string, tag = "5")]
+    pub name: ::prost::alloc::string::String,
+    /// If this field is empty, all custom and
+    /// system-defined metric descriptors are returned.
+    /// Otherwise, the \[filter\](<https://cloud.google.com/monitoring/api/v3/filters>)
+    /// specifies which metric descriptors are to be
+    /// returned. For example, the following filter matches all
+    /// [custom metrics](<https://cloud.google.com/monitoring/custom-metrics>):
+    ///
+    /// ```text
+    /// metric.type = starts_with("custom.googleapis.com/")
+    /// ```
+    #[prost(string, tag = "2")]
+    pub filter: ::prost::alloc::string::String,
+    /// A positive number that is the maximum number of results to return.
+    #[prost(int32, tag = "3")]
+    pub page_size: i32,
+    /// If this field is not empty then it must contain the `nextPageToken` value
+    /// returned by a previous call to this method.  Using this field causes the
+    /// method to return additional results from the previous method call.
+    #[prost(string, tag = "4")]
+    pub page_token: ::prost::alloc::string::String,
+}
+/// The `ListMetricDescriptors` response.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListMetricDescriptorsResponse {
+    /// The metric descriptors that are available to the project
+    /// and that match the value of `filter`, if present.
+    #[prost(message, repeated, tag = "1")]
+    pub metric_descriptors: ::prost::alloc::vec::Vec<
+        super::super::api::MetricDescriptor,
+    >,
+    /// If there are more results than have been returned, then this field is set
+    /// to a non-empty value.  To see the additional results,
+    /// use that value as `page_token` in the next call to this method.
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+}
+/// The `GetMetricDescriptor` request.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetMetricDescriptorRequest {
+    /// Required. The metric descriptor on which to execute the request. The format is:
+    ///
+    /// ```text
+    /// projects/\[PROJECT_ID_OR_NUMBER]/metricDescriptors/[METRIC_ID\]
+    /// ```
+    ///
+    /// An example value of `\[METRIC_ID\]` is
+    /// `"compute.googleapis.com/instance/disk/read_bytes_count"`.
+    #[prost(string, tag = "3")]
+    pub name: ::prost::alloc::string::String,
+}
+/// The `CreateMetricDescriptor` request.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateMetricDescriptorRequest {
+    /// Required. The \[project\](<https://cloud.google.com/monitoring/api/v3#project_name>) on
+    /// which to execute the request. The format is:
+    /// 4
+    /// projects/\\[PROJECT_ID_OR_NUMBER\\]
+    #[prost(string, tag = "3")]
+    pub name: ::prost::alloc::string::String,
+    /// Required. The new [custom metric](<https://cloud.google.com/monitoring/custom-metrics>)
+    /// descriptor.
+    #[prost(message, optional, tag = "2")]
+    pub metric_descriptor: ::core::option::Option<super::super::api::MetricDescriptor>,
+}
+/// The `DeleteMetricDescriptor` request.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteMetricDescriptorRequest {
+    /// Required. The metric descriptor on which to execute the request. The format is:
+    ///
+    /// ```text
+    /// projects/\[PROJECT_ID_OR_NUMBER]/metricDescriptors/[METRIC_ID\]
+    /// ```
+    ///
+    /// An example of `\[METRIC_ID\]` is:
+    /// `"custom.googleapis.com/my_test_metric"`.
+    #[prost(string, tag = "3")]
+    pub name: ::prost::alloc::string::String,
+}
+/// The `ListTimeSeries` request.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListTimeSeriesRequest {
+    /// Required. The \[project\](<https://cloud.google.com/monitoring/api/v3#project_name>),
+    /// organization or folder on which to execute the request. The format is:
+    ///
+    /// ```text
+    /// projects/\[PROJECT_ID_OR_NUMBER\]
+    /// organizations/\[ORGANIZATION_ID\]
+    /// folders/\[FOLDER_ID\]
+    /// ```
+    #[prost(string, tag = "10")]
+    pub name: ::prost::alloc::string::String,
+    /// Required. A [monitoring filter](<https://cloud.google.com/monitoring/api/v3/filters>)
+    /// that specifies which time series should be returned.  The filter must
+    /// specify a single metric type, and can additionally specify metric labels
+    /// and other information. For example:
+    ///
+    /// ```text
+    /// metric.type = "compute.googleapis.com/instance/cpu/usage_time" AND
+    ///      metric.labels.instance_name = "my-instance-name"
+    /// ```
+    #[prost(string, tag = "2")]
+    pub filter: ::prost::alloc::string::String,
+    /// Required. The time interval for which results should be returned. Only time series
+    /// that contain data points in the specified interval are included
+    /// in the response.
+    #[prost(message, optional, tag = "4")]
+    pub interval: ::core::option::Option<TimeInterval>,
+    /// Specifies the alignment of data points in individual time series as
+    /// well as how to combine the retrieved time series across specified labels.
+    ///
+    /// By default (if no `aggregation` is explicitly specified), the raw time
+    /// series data is returned.
+    #[prost(message, optional, tag = "5")]
+    pub aggregation: ::core::option::Option<Aggregation>,
+    /// Apply a second aggregation after `aggregation` is applied. May only be
+    /// specified if `aggregation` is specified.
+    #[prost(message, optional, tag = "11")]
+    pub secondary_aggregation: ::core::option::Option<Aggregation>,
+    /// Unsupported: must be left blank. The points in each time series are
+    /// currently returned in reverse time order (most recent to oldest).
+    #[prost(string, tag = "6")]
+    pub order_by: ::prost::alloc::string::String,
+    /// Required. Specifies which information is returned about the time series.
+    #[prost(enumeration = "list_time_series_request::TimeSeriesView", tag = "7")]
+    pub view: i32,
+    /// A positive number that is the maximum number of results to return. If
+    /// `page_size` is empty or more than 100,000 results, the effective
+    /// `page_size` is 100,000 results. If `view` is set to `FULL`, this is the
+    /// maximum number of `Points` returned. If `view` is set to `HEADERS`, this is
+    /// the maximum number of `TimeSeries` returned.
+    #[prost(int32, tag = "8")]
+    pub page_size: i32,
+    /// If this field is not empty then it must contain the `nextPageToken` value
+    /// returned by a previous call to this method.  Using this field causes the
+    /// method to return additional results from the previous method call.
+    #[prost(string, tag = "9")]
+    pub page_token: ::prost::alloc::string::String,
+}
+/// Nested message and enum types in `ListTimeSeriesRequest`.
+pub mod list_time_series_request {
+    /// Controls which fields are returned by `ListTimeSeries`.
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum TimeSeriesView {
+        /// Returns the identity of the metric(s), the time series,
+        /// and the time series data.
+        Full = 0,
+        /// Returns the identity of the metric and the time series resource,
+        /// but not the time series data.
+        Headers = 1,
+    }
+    impl TimeSeriesView {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                TimeSeriesView::Full => "FULL",
+                TimeSeriesView::Headers => "HEADERS",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "FULL" => Some(Self::Full),
+                "HEADERS" => Some(Self::Headers),
+                _ => None,
+            }
+        }
+    }
+}
+/// The `ListTimeSeries` response.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListTimeSeriesResponse {
+    /// One or more time series that match the filter included in the request.
+    #[prost(message, repeated, tag = "1")]
+    pub time_series: ::prost::alloc::vec::Vec<TimeSeries>,
+    /// If there are more results than have been returned, then this field is set
+    /// to a non-empty value.  To see the additional results,
+    /// use that value as `page_token` in the next call to this method.
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+    /// Query execution errors that may have caused the time series data returned
+    /// to be incomplete.
+    #[prost(message, repeated, tag = "3")]
+    pub execution_errors: ::prost::alloc::vec::Vec<super::super::rpc::Status>,
+    /// The unit in which all `time_series` point values are reported. `unit`
+    /// follows the UCUM format for units as seen in
+    /// <https://unitsofmeasure.org/ucum.html.>
+    /// If different `time_series` have different units (for example, because they
+    /// come from different metric types, or a unit is absent), then `unit` will be
+    /// "{not_a_unit}".
+    #[prost(string, tag = "5")]
+    pub unit: ::prost::alloc::string::String,
+}
+/// The `CreateTimeSeries` request.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateTimeSeriesRequest {
+    /// Required. The \[project\](<https://cloud.google.com/monitoring/api/v3#project_name>) on
+    /// which to execute the request. The format is:
+    ///
+    /// ```text
+    /// projects/\[PROJECT_ID_OR_NUMBER\]
+    /// ```
+    #[prost(string, tag = "3")]
+    pub name: ::prost::alloc::string::String,
+    /// Required. The new data to be added to a list of time series.
+    /// Adds at most one data point to each of several time series.  The new data
+    /// point must be more recent than any other point in its time series.  Each
+    /// `TimeSeries` value must fully specify a unique time series by supplying
+    /// all label values for the metric and the monitored resource.
+    ///
+    /// The maximum number of `TimeSeries` objects per `Create` request is 200.
+    #[prost(message, repeated, tag = "2")]
+    pub time_series: ::prost::alloc::vec::Vec<TimeSeries>,
+}
+/// DEPRECATED. Used to hold per-time-series error status.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateTimeSeriesError {
+    /// DEPRECATED. Time series ID that resulted in the `status` error.
+    #[deprecated]
+    #[prost(message, optional, tag = "1")]
+    pub time_series: ::core::option::Option<TimeSeries>,
+    /// DEPRECATED. The status of the requested write operation for `time_series`.
+    #[deprecated]
+    #[prost(message, optional, tag = "2")]
+    pub status: ::core::option::Option<super::super::rpc::Status>,
+}
+/// Summary of the result of a failed request to write data to a time series.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateTimeSeriesSummary {
+    /// The number of points in the request.
+    #[prost(int32, tag = "1")]
+    pub total_point_count: i32,
+    /// The number of points that were successfully written.
+    #[prost(int32, tag = "2")]
+    pub success_point_count: i32,
+    /// The number of points that failed to be written. Order is not guaranteed.
+    #[prost(message, repeated, tag = "3")]
+    pub errors: ::prost::alloc::vec::Vec<create_time_series_summary::Error>,
+}
+/// Nested message and enum types in `CreateTimeSeriesSummary`.
+pub mod create_time_series_summary {
+    /// Detailed information about an error category.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Error {
+        /// The status of the requested write operation.
+        #[prost(message, optional, tag = "1")]
+        pub status: ::core::option::Option<super::super::super::rpc::Status>,
+        /// The number of points that couldn't be written because of `status`.
+        #[prost(int32, tag = "2")]
+        pub point_count: i32,
+    }
+}
+/// The `QueryTimeSeries` request.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryTimeSeriesRequest {
+    /// Required. The \[project\](<https://cloud.google.com/monitoring/api/v3#project_name>) on
+    /// which to execute the request. The format is:
+    ///
+    /// ```text
+    /// projects/\[PROJECT_ID_OR_NUMBER\]
+    /// ```
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Required. The query in the [Monitoring Query
+    /// Language](<https://cloud.google.com/monitoring/mql/reference>) format.
+    /// The default time zone is in UTC.
+    #[prost(string, tag = "7")]
+    pub query: ::prost::alloc::string::String,
+    /// A positive number that is the maximum number of time_series_data to return.
+    #[prost(int32, tag = "9")]
+    pub page_size: i32,
+    /// If this field is not empty then it must contain the `nextPageToken` value
+    /// returned by a previous call to this method.  Using this field causes the
+    /// method to return additional results from the previous method call.
+    #[prost(string, tag = "10")]
+    pub page_token: ::prost::alloc::string::String,
+}
+/// The `QueryTimeSeries` response.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryTimeSeriesResponse {
+    /// The descriptor for the time series data.
+    #[prost(message, optional, tag = "8")]
+    pub time_series_descriptor: ::core::option::Option<TimeSeriesDescriptor>,
+    /// The time series data.
+    #[prost(message, repeated, tag = "9")]
+    pub time_series_data: ::prost::alloc::vec::Vec<TimeSeriesData>,
+    /// If there are more results than have been returned, then this field is set
+    /// to a non-empty value.  To see the additional results, use that value as
+    /// `page_token` in the next call to this method.
+    #[prost(string, tag = "10")]
+    pub next_page_token: ::prost::alloc::string::String,
+    /// Query execution errors that may have caused the time series data returned
+    /// to be incomplete. The available data will be available in the
+    /// response.
+    #[prost(message, repeated, tag = "11")]
+    pub partial_errors: ::prost::alloc::vec::Vec<super::super::rpc::Status>,
+}
+/// This is an error detail intended to be used with INVALID_ARGUMENT errors.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryErrorList {
+    /// Errors in parsing the time series query language text. The number of errors
+    /// in the response may be limited.
+    #[prost(message, repeated, tag = "1")]
+    pub errors: ::prost::alloc::vec::Vec<QueryError>,
+    /// A summary of all the errors.
+    #[prost(string, tag = "2")]
+    pub error_summary: ::prost::alloc::string::String,
+}
+/// Generated client implementations.
+pub mod metric_service_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    /// Manages metric descriptors, monitored resource descriptors, and
+    /// time series data.
+    #[derive(Debug, Clone)]
+    pub struct MetricServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl MetricServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MetricServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> MetricServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            MetricServiceClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// Lists monitored resource descriptors that match a filter. This method does not require a Workspace.
+        pub async fn list_monitored_resource_descriptors(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::ListMonitoredResourceDescriptorsRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::ListMonitoredResourceDescriptorsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.monitoring.v3.MetricService/ListMonitoredResourceDescriptors",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.monitoring.v3.MetricService",
+                        "ListMonitoredResourceDescriptors",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Gets a single monitored resource descriptor. This method does not require a Workspace.
+        pub async fn get_monitored_resource_descriptor(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::GetMonitoredResourceDescriptorRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::api::MonitoredResourceDescriptor>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.monitoring.v3.MetricService/GetMonitoredResourceDescriptor",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.monitoring.v3.MetricService",
+                        "GetMonitoredResourceDescriptor",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Lists metric descriptors that match a filter. This method does not require a Workspace.
+        pub async fn list_metric_descriptors(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListMetricDescriptorsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ListMetricDescriptorsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.monitoring.v3.MetricService/ListMetricDescriptors",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.monitoring.v3.MetricService",
+                        "ListMetricDescriptors",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Gets a single metric descriptor. This method does not require a Workspace.
+        pub async fn get_metric_descriptor(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetMetricDescriptorRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::api::MetricDescriptor>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.monitoring.v3.MetricService/GetMetricDescriptor",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.monitoring.v3.MetricService",
+                        "GetMetricDescriptor",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Creates a new metric descriptor.
+        /// The creation is executed asynchronously and callers may check the returned
+        /// operation to track its progress.
+        /// User-created metric descriptors define
+        /// [custom metrics](https://cloud.google.com/monitoring/custom-metrics).
+        pub async fn create_metric_descriptor(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateMetricDescriptorRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::api::MetricDescriptor>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.monitoring.v3.MetricService/CreateMetricDescriptor",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.monitoring.v3.MetricService",
+                        "CreateMetricDescriptor",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Deletes a metric descriptor. Only user-created
+        /// [custom metrics](https://cloud.google.com/monitoring/custom-metrics) can be
+        /// deleted.
+        pub async fn delete_metric_descriptor(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteMetricDescriptorRequest>,
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.monitoring.v3.MetricService/DeleteMetricDescriptor",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.monitoring.v3.MetricService",
+                        "DeleteMetricDescriptor",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Lists time series that match a filter. This method does not require a Workspace.
+        pub async fn list_time_series(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListTimeSeriesRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ListTimeSeriesResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.monitoring.v3.MetricService/ListTimeSeries",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.monitoring.v3.MetricService",
+                        "ListTimeSeries",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Creates or adds data to one or more time series.
+        /// The response is empty if all time series in the request were written.
+        /// If any time series could not be written, a corresponding failure message is
+        /// included in the error response.
+        pub async fn create_time_series(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateTimeSeriesRequest>,
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.monitoring.v3.MetricService/CreateTimeSeries",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.monitoring.v3.MetricService",
+                        "CreateTimeSeries",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Creates or adds data to one or more service time series. A service time
+        /// series is a time series for a metric from a Google Cloud service. The
+        /// response is empty if all time series in the request were written. If any
+        /// time series could not be written, a corresponding failure message is
+        /// included in the error response. This endpoint rejects writes to
+        /// user-defined metrics.
+        /// This method is only for use by Google Cloud services. Use
+        /// \[projects.timeSeries.create\]\[google.monitoring.v3.MetricService.CreateTimeSeries\]
+        /// instead.
+        pub async fn create_service_time_series(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateTimeSeriesRequest>,
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.monitoring.v3.MetricService/CreateServiceTimeSeries",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.monitoring.v3.MetricService",
+                        "CreateServiceTimeSeries",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}

--- a/sdk/src/services/gcloud/mod.rs
+++ b/sdk/src/services/gcloud/mod.rs
@@ -416,16 +416,18 @@ impl GCloudClient {
                                         let cpu_utilization_point =
                                             response.time_series[0].points[0].clone();
                                         let cpu_utilization = match cpu_utilization_point.value {
-                                            Some(typed_value) => match typed_value {
-                                                TypedValue { value } => match value {
+                                            Some(typed_value) => {
+                                                let TypedValue { value } = typed_value;
+                                                match value {
                                                     Some(google::monitoring::v3::typed_value::Value::DoubleValue(
                                                         double_value,
                                                     )) => double_value * 100.0, // Convert to percentage
                                                     _ => 0.0,
-                                                },
-                                            },
+                                                    }
+                                            }
                                             None => 0.0,
                                         };
+
                                         metrics_values.insert(
                                             MetricType::CpuUtilization,
                                             MetricValue::CpuUtilization(cpu_utilization),
@@ -435,42 +437,45 @@ impl GCloudClient {
                                         let memory_cache_point =
                                             response.time_series[0].points[0].clone();
                                         let memory_cache = match memory_cache_point.value {
-                                            Some(typed_value) => match typed_value {
-                                                TypedValue { value } => match value {
+                                            Some(typed_value) => {
+                                                let TypedValue { value } = typed_value;
+                                                match value {
                                                     Some(google::monitoring::v3::typed_value::Value::DoubleValue(
                                                         double_value,
                                                     )) => double_value, // Already a percentage
                                                     _ => 0.0,
-                                                },
-                                            },
+                                                }
+                                            }
                                             None => 0.0,
                                         };
 
                                         let memory_free_point =
                                             response.time_series[1].points[0].clone();
                                         let memory_free = match memory_free_point.value {
-                                            Some(typed_value) => match typed_value {
-                                                TypedValue { value } => match value {
+                                            Some(typed_value) => {
+                                                let TypedValue { value } = typed_value;
+                                                match value {
                                                     Some(google::monitoring::v3::typed_value::Value::DoubleValue(
                                                         double_value,
                                                     )) => double_value, // Already a percentage
                                                     _ => 0.0,
-                                                },
-                                            },
+                                                }
+                                            }
                                             None => 0.0,
                                         };
 
                                         let memory_usage_point =
                                             response.time_series[2].points[0].clone();
                                         let memory_usage = match memory_usage_point.value {
-                                            Some(typed_value) => match typed_value {
-                                                TypedValue { value } => match value {
+                                            Some(typed_value) => {
+                                                let TypedValue { value } = typed_value;
+                                                match value {
                                                     Some(google::monitoring::v3::typed_value::Value::DoubleValue(
                                                         double_value,
                                                     )) => double_value, // Already a percentage
                                                     _ => 0.0,
-                                                },
-                                            },
+                                                }
+                                            }
                                             None => 0.0,
                                         };
 
@@ -540,7 +545,7 @@ impl GCloudClient {
             }
         }
 
-        grouped_responses.keys().into_iter().for_each(|key| {
+        grouped_responses.keys().for_each(|key| {
             let cpu_utilization_option = grouped_responses
                 .get(key)
                 .unwrap()
@@ -590,10 +595,10 @@ impl GCloudClient {
             database_metrics.push(DatabaseMetrics {
                 name: key.to_string(),
                 cpu_utilization,
-                memory_usage: memory_usage.clone(),
-                memory_free: memory_free.clone(),
-                memory_cache: memory_cache.clone(),
-                connections_count: connections_count.clone(),
+                memory_usage,
+                memory_free,
+                memory_cache,
+                connections_count,
             });
         });
 

--- a/sdk/src/services/gcloud/mod.rs
+++ b/sdk/src/services/gcloud/mod.rs
@@ -21,14 +21,12 @@ pub mod google {
 }
 
 use self::google::{
-    api::Metric,
     logging::v2::{log_entry, LogEntry},
     monitoring::v3::{
         aggregation::{Aligner, Reducer},
         list_time_series_request::TimeSeriesView,
         metric_service_client::MetricServiceClient,
-        Aggregation, ListTimeSeriesRequest, ListTimeSeriesResponse, Point, TimeInterval,
-        TimeSeries, TypedValue,
+        Aggregation, ListTimeSeriesRequest, ListTimeSeriesResponse, TimeInterval, TypedValue,
     },
 };
 use crate::{
@@ -39,7 +37,7 @@ use chrono::{DateTime, Duration, Utc};
 use google::logging::v2::{
     logging_service_v2_client::LoggingServiceV2Client, ListLogEntriesRequest,
 };
-use log::info;
+
 use prost_types::Timestamp;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -502,7 +500,7 @@ impl GCloudClient {
                                 MetricType::ConnectionsCount => {
                                     metrics_values.insert(
                                         MetricType::ConnectionsCount,
-                                        MetricValue::ConnectionsCount(0),
+                                        MetricValue::ConnectionsCount(2000),
                                     );
 
                                     // let connections_count_point =
@@ -572,13 +570,25 @@ impl GCloudClient {
                 _ => 0.0,
             };
 
+            let connections_counts_option = grouped_responses
+                .get(key)
+                .unwrap()
+                .get(&MetricType::ConnectionsCount)
+                .unwrap()
+                .clone();
+
+            let connections_count = match connections_counts_option {
+                MetricValue::ConnectionsCount(connections_count) => connections_count,
+                _ => 0,
+            };
+
             database_instances.push(DatabaseInstance {
                 name: key.to_string(),
                 cpu_utilization: cpu_utilization,
                 memory_usage: memory_usage.clone(),
                 memory_free: memory_free.clone(),
                 memory_cache: memory_cache.clone(),
-                connections_count: 0,
+                connections_count: connections_count.clone(),
             });
         });
 

--- a/sdk/src/services/gcloud/mod.rs
+++ b/sdk/src/services/gcloud/mod.rs
@@ -433,6 +433,10 @@ impl GCloudClient {
                                             MetricValue::CpuUtilization(cpu_utilization),
                                         );
                                     }
+                                    // For the other MetricTypes, we've aggregated them so that there
+                                    // is only one TimeSeries with one point in the response, so we can
+                                    // just take the first. But for MemoryComponents, we get three TimeSeries,
+                                    // one for each component (cache, free, usage).
                                     MetricType::MemoryComponents => {
                                         let memory_cache_point =
                                             response.time_series[0].points[0].clone();

--- a/sdk/src/services/gcloud/mod.rs
+++ b/sdk/src/services/gcloud/mod.rs
@@ -102,25 +102,13 @@ impl Display for MetricTypeFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MetricTypeFilter::CpuUtilization => {
-                write!(
-                    f,
-                    "metric.type=\"{}\"",
-                    format!("{}", MetricType::CpuUtilization)
-                )
+                write!(f, "metric.type=\"{}\"", MetricType::CpuUtilization)
             }
             MetricTypeFilter::MemoryComponents => {
-                write!(
-                    f,
-                    "metric.type=\"{}\"",
-                    format!("{}", MetricType::MemoryComponents)
-                )
+                write!(f, "metric.type=\"{}\"", MetricType::MemoryComponents)
             }
             MetricTypeFilter::ConnectionsCount => {
-                write!(
-                    f,
-                    "metric.type=\"{}\"",
-                    format!("{}", MetricType::ConnectionsCount)
-                )
+                write!(f, "metric.type=\"{}\"", MetricType::ConnectionsCount)
             }
         }
     }
@@ -378,7 +366,7 @@ impl GCloudClient {
                 });
 
             let request: ListTimeSeriesRequest = generate_request(
-                &format!("{}", metric_type).as_str(),
+                format!("{}", metric_type).as_str(),
                 project_id,
                 &start_time,
                 &current_time,
@@ -391,7 +379,7 @@ impl GCloudClient {
         let mut grouped_responses: HashMap<String, MetricHash> = HashMap::new();
 
         for response in &responses {
-            if response.time_series.len() > 0 {
+            if !response.time_series.is_empty() {
                 let database_ids: Vec<Option<&String>> = response
                     .time_series
                     .iter()
@@ -601,7 +589,7 @@ impl GCloudClient {
 
             database_metrics.push(DatabaseMetrics {
                 name: key.to_string(),
-                cpu_utilization: cpu_utilization,
+                cpu_utilization,
                 memory_usage: memory_usage.clone(),
                 memory_free: memory_free.clone(),
                 memory_cache: memory_cache.clone(),

--- a/sdk/src/services/gcloud/mod.rs
+++ b/sdk/src/services/gcloud/mod.rs
@@ -353,8 +353,6 @@ impl GCloudClient {
     /// a Vector of `DatabaseMetrics`s that is updated on the App's `state.databases.database_metrics`.
     pub async fn get_database_metrics(
         &self,
-        _application: &str,
-        _namespace: &str,
         project_id: &str,
     ) -> Result<Vec<DatabaseMetrics>, GCloudError> {
         let mut database_metrics = Vec::new();
@@ -630,14 +628,12 @@ impl WKClient {
 
     pub async fn get_gcloud_database_metrics(
         &self,
-        application: &str,
-        namespace: &str,
         project_id: &str,
         access_token: String,
     ) -> Result<Vec<DatabaseMetrics>, WKError> {
         let google_client = GCloudClient::new(access_token);
         google_client
-            .get_database_metrics(application, namespace, project_id)
+            .get_database_metrics(project_id)
             .await
             .map_err(|err| err.into())
     }

--- a/sdk/src/services/gcloud/mod.rs
+++ b/sdk/src/services/gcloud/mod.rs
@@ -350,14 +350,14 @@ impl GCloudClient {
 
     /// Here we get the database metrics from Google Cloud by sending a request using the `MetricServiceClient`
     /// for each `MetricTypeFilter` that we have defined. The responses for the requests are then extracted into
-    /// a Vector of `DatabaseMetrics`s that is updated on the App's `state.databases.database_instances`.
+    /// a Vector of `DatabaseMetrics`s that is updated on the App's `state.databases.database_metrics`.
     pub async fn get_database_metrics(
         &self,
         _application: &str,
         _namespace: &str,
         project_id: &str,
     ) -> Result<Vec<DatabaseMetrics>, GCloudError> {
-        let mut database_instances = Vec::new();
+        let mut database_metrics = Vec::new();
         let current_time = Utc::now();
         let start_time = current_time - Duration::minutes(3);
         let mut responses: Vec<ListTimeSeriesResponse> = Vec::new();
@@ -590,7 +590,7 @@ impl GCloudClient {
                 _ => 0,
             };
 
-            database_instances.push(DatabaseMetrics {
+            database_metrics.push(DatabaseMetrics {
                 name: key.to_string(),
                 cpu_utilization: cpu_utilization,
                 memory_usage: memory_usage.clone(),
@@ -600,7 +600,7 @@ impl GCloudClient {
             });
         });
 
-        Ok(database_instances)
+        Ok(database_metrics)
     }
 }
 

--- a/sdk/src/services/gcloud/mod.rs
+++ b/sdk/src/services/gcloud/mod.rs
@@ -231,12 +231,12 @@ impl WKClient {
     /// Get log entries from Google Cloud.
     pub async fn get_gcloud_log_entries(
         &self,
-        optons: LogEntriesOptions,
+        options: LogEntriesOptions,
         access_token: String,
     ) -> Result<LogEntries, WKError> {
         let google_client = GCloudClient::new(access_token);
         google_client
-            .get_log_entries(optons)
+            .get_log_entries(options)
             .await
             .map_err(|err| err.into())
     }

--- a/sdk/src/services/gcloud/mod.rs
+++ b/sdk/src/services/gcloud/mod.rs
@@ -20,18 +20,127 @@ pub mod google {
 
 }
 
-use self::google::logging::v2::{log_entry, LogEntry};
+use self::google::{
+    api::Metric,
+    logging::v2::{log_entry, LogEntry},
+    monitoring::v3::{
+        aggregation::{Aligner, Reducer},
+        list_time_series_request::TimeSeriesView,
+        metric_service_client::MetricServiceClient,
+        Aggregation, ListTimeSeriesRequest, ListTimeSeriesResponse, Point, TimeInterval,
+        TimeSeries, TypedValue,
+    },
+};
 use crate::{
     error::{GCloudError, WKError},
     WKClient,
 };
-use chrono::Duration;
+use chrono::{DateTime, Duration, Utc};
 use google::logging::v2::{
     logging_service_v2_client::LoggingServiceV2Client, ListLogEntriesRequest,
 };
+use log::info;
+use prost_types::Timestamp;
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
+use std::str::FromStr;
+use std::{collections::HashMap, fmt::Display};
+
+use strum::{EnumIter, IntoEnumIterator};
 use tonic::{metadata::MetadataValue, transport::Channel, Request};
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+enum MetricType {
+    CpuUtilization,
+    MemoryComponents,
+    ConnectionsCount,
+}
+
+#[derive(EnumIter, Debug)]
+enum MetricTypeFilter {
+    CpuUtilization,
+    MemoryComponents,
+    ConnectionsCount,
+}
+
+type MetricHash = HashMap<MetricType, MetricValue>;
+
+impl Display for MetricType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MetricType::CpuUtilization => {
+                write!(f, "cloudsql.googleapis.com/database/cpu/utilization")
+            }
+            MetricType::MemoryComponents => {
+                write!(f, "cloudsql.googleapis.com/database/memory/components")
+            }
+            MetricType::ConnectionsCount => {
+                write!(
+                    f,
+                    "cloudsql.googleapis.com/database/postgresql/num_backends"
+                )
+            }
+        }
+    }
+}
+
+impl FromStr for MetricType {
+    type Err = GCloudError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cloudsql.googleapis.com/database/cpu/utilization" => Ok(MetricType::CpuUtilization),
+            "cloudsql.googleapis.com/database/memory/components" => {
+                Ok(MetricType::MemoryComponents)
+            }
+            "cloudsql.googleapis.com/database/postgresql/num_backends" => {
+                Ok(MetricType::ConnectionsCount)
+            }
+            _ => Err(GCloudError::InvalidMetricType),
+        }
+    }
+}
+
+impl Display for MetricTypeFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MetricTypeFilter::CpuUtilization => {
+                write!(
+                    f,
+                    "metric.type=\"{}\"",
+                    format!("{}", MetricType::CpuUtilization)
+                )
+            }
+            MetricTypeFilter::MemoryComponents => {
+                write!(
+                    f,
+                    "metric.type=\"{}\"",
+                    format!("{}", MetricType::MemoryComponents)
+                )
+            }
+            MetricTypeFilter::ConnectionsCount => {
+                write!(
+                    f,
+                    "metric.type=\"{}\"",
+                    format!("{}", MetricType::ConnectionsCount)
+                )
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum MetricValue {
+    CpuUtilization(f64),
+    MemoryComponents(MetricsMemoryComponents),
+    ConnectionsCount(i64),
+}
+
+#[derive(Debug, Clone)]
+struct MetricsMemoryComponents {
+    cache: f64,
+    free: f64,
+    usage: f64,
+}
 
 impl Display for LogEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -156,6 +265,14 @@ pub struct LogEntries {
     pub next_page_token: Option<String>,
 }
 
+#[derive(Debug)]
+pub struct DatabaseInstance {
+    pub name: String,
+    pub cpu_utilization: f64,
+    pub memory_utilization: f64,
+    pub connections_count: i64,
+}
+
 pub struct GCloudClient {
     access_token: String,
 }
@@ -230,6 +347,203 @@ impl GCloudClient {
 
         Ok(token_info)
     }
+
+    /// Here we get the database metrics from Google Cloud by sending a request using the `MetricServiceClient`
+    /// for each `MetricTypeFilter` that we have defined. The responses for the requests are then extracted into
+    /// a Vector of `DatabaseInstance`s that is updated on the App's `state.databases.database_instances`.
+    pub async fn get_database_metrics(
+        &self,
+        _application: &str,
+        _namespace: &str,
+        project_id: &str,
+    ) -> Result<Vec<DatabaseInstance>, GCloudError> {
+        let mut database_instances = Vec::new();
+        let current_time = Utc::now();
+        let start_time = current_time - Duration::minutes(10);
+        let mut responses: Vec<ListTimeSeriesResponse> = Vec::new();
+
+        for metric_type in MetricTypeFilter::iter() {
+            let bearer_token = format!("Bearer {}", self.access_token);
+            let header_value: MetadataValue<_> = bearer_token.parse().unwrap();
+            let channel = Channel::from_static("https://monitoring.googleapis.com")
+                .connect()
+                .await
+                .unwrap();
+
+            let mut service =
+                MetricServiceClient::with_interceptor(channel, move |mut req: Request<()>| {
+                    let metadata_map = req.metadata_mut();
+                    metadata_map.insert("authorization", header_value.clone());
+                    metadata_map.insert("user-agent", "grpc-go/1.14".parse().unwrap());
+
+                    Ok(req)
+                });
+
+            let request: ListTimeSeriesRequest = generate_request(
+                &format!("{}", metric_type).as_str(),
+                project_id,
+                &start_time,
+                &current_time,
+            );
+
+            let response = service.list_time_series(Request::new(request.clone()));
+
+            responses.push(response.await?.into_inner());
+        }
+        let mut grouped_responses: HashMap<String, MetricHash> = HashMap::new();
+
+        for response in &responses {
+            let database_id = response.time_series[0]
+                .resource
+                .as_ref()
+                .unwrap()
+                .labels
+                .get("database_id");
+            match database_id {
+                Some(database_id) => {
+                    if grouped_responses.get(database_id).is_none() {
+                        grouped_responses.insert(database_id.to_string(), HashMap::new());
+                    };
+                    let mut metrics_values = grouped_responses[database_id].clone();
+
+                    let metric_type = MetricType::from_str(
+                        response.time_series[0]
+                            .metric
+                            .as_ref()
+                            .unwrap()
+                            .r#type
+                            .as_str(),
+                    );
+
+                    match metric_type {
+                        Ok(valid_type) => match valid_type {
+                            MetricType::CpuUtilization => {
+                                let cpu_utilization_point =
+                                    response.time_series[0].points[0].clone();
+                                let cpu_utilization = match cpu_utilization_point.value {
+                                    Some(typed_value) => match typed_value {
+                                        TypedValue { value } => match value {
+                                            Some(google::monitoring::v3::typed_value::Value::DoubleValue(
+                                                double_value,
+                                            )) => double_value * 100.0, // Convert to percentage
+                                            _ => 0.0,
+                                        },
+                                    },
+                                    None => 0.0,
+                                };
+                                metrics_values.insert(
+                                    MetricType::CpuUtilization,
+                                    MetricValue::CpuUtilization(cpu_utilization),
+                                );
+                            }
+                            MetricType::MemoryComponents => {
+                                let memory_cache_point = response.time_series[0].points[0].clone();
+                                let memory_cache = match memory_cache_point.value {
+                                    Some(typed_value) => match typed_value {
+                                        TypedValue { value } => match value {
+                                            Some(google::monitoring::v3::typed_value::Value::DoubleValue(
+                                                double_value,
+                                            )) => double_value, // Already a percentage
+                                            _ => 0.0,
+                                        },
+                                    },
+                                    None => 0.0,
+                                };
+
+                                let memory_free_point = response.time_series[1].points[0].clone();
+                                let memory_free = match memory_free_point.value {
+                                    Some(typed_value) => match typed_value {
+                                        TypedValue { value } => match value {
+                                            Some(google::monitoring::v3::typed_value::Value::DoubleValue(
+                                                double_value,
+                                            )) => double_value, // Already a percentage
+                                            _ => 0.0,
+                                        },
+                                    },
+                                    None => 0.0,
+                                };
+
+                                let memory_usage_point = response.time_series[2].points[0].clone();
+                                let memory_usage = match memory_usage_point.value {
+                                    Some(typed_value) => match typed_value {
+                                        TypedValue { value } => match value {
+                                            Some(google::monitoring::v3::typed_value::Value::DoubleValue(
+                                                double_value,
+                                            )) => double_value, // Already a percentage
+                                            _ => 0.0,
+                                        },
+                                    },
+                                    None => 0.0,
+                                };
+
+                                metrics_values.insert(
+                                    MetricType::MemoryComponents,
+                                    MetricValue::MemoryComponents(MetricsMemoryComponents {
+                                        cache: memory_cache,
+                                        free: memory_free,
+                                        usage: memory_usage,
+                                    }),
+                                );
+                            }
+                            MetricType::ConnectionsCount => {
+                                metrics_values.insert(
+                                    MetricType::ConnectionsCount,
+                                    MetricValue::ConnectionsCount(0),
+                                );
+                            }
+                        },
+                        Err(_err) => continue,
+                    }
+
+                    grouped_responses.insert(database_id.to_string(), metrics_values);
+                }
+                None => {
+                    continue; // We don't do anything with the response if we can't get the database_id
+                }
+            }
+        }
+
+        todo!("Get memory utilization {:?}", grouped_responses);
+        // grouped_responses.keys().into_iter().for_each(|key| {
+        //     let time_series = grouped_responses.get(key).unwrap();
+        //     let cpu_utilization_point = time_series[0][0].points[0].clone();
+
+        //     let cpu_utilization = match cpu_utilization_point.value {
+        //         Some(typed_value) => match typed_value {
+        //             TypedValue { value } => match value {
+        //                 Some(google::monitoring::v3::typed_value::Value::DoubleValue(
+        //                     double_value,
+        //                 )) => double_value * 100.0,
+        //                 _ => 0.0,
+        //             },
+        //         },
+        //         None => 0.0,
+        //     };
+
+        //     let memory_utilization_point = time_series[1][0].points[0].clone();
+
+        //     let memory_utilization = match memory_utilization_point.value {
+        //         Some(typed_value) => match typed_value {
+        //             TypedValue { value } => match value {
+        //                 Some(google::monitoring::v3::typed_value::Value::DoubleValue(
+        //                     double_value,
+        //                 )) => double_value * 100.0,
+        //                 _ => 0.0,
+        //             },
+        //         },
+        //         None => 0.0,
+        //     };
+
+        //     database_instances.push(DatabaseInstance {
+        //         name: key.to_string(),
+        //         cpu_utilization: cpu_utilization,
+        //         memory_utilization: memory_utilization,
+        //         connections_count: 3,
+        //     });
+        // });
+
+        Ok(database_instances)
+    }
 }
 
 /// Functions from Google Cloud service.
@@ -254,5 +568,55 @@ impl WKClient {
             .get_access_token_info()
             .await
             .map_err(|err| err.into())
+    }
+
+    pub async fn get_gcloud_database_metrics(
+        &self,
+        application: &str,
+        namespace: &str,
+        project_id: &str,
+        access_token: String,
+    ) -> Result<Vec<DatabaseInstance>, WKError> {
+        let google_client = GCloudClient::new(access_token);
+        google_client
+            .get_database_metrics(application, namespace, project_id)
+            .await
+            .map_err(|err| err.into())
+    }
+}
+
+fn generate_request(
+    metric_type: &str,
+    project_id: &str,
+    start_time: &DateTime<Utc>,
+    end_time: &DateTime<Utc>,
+) -> ListTimeSeriesRequest {
+    ListTimeSeriesRequest {
+        name: format!("projects/{}", project_id),
+        filter: metric_type.to_string(),
+        interval: Some(TimeInterval {
+            start_time: Some(Timestamp {
+                seconds: start_time.timestamp(),
+                nanos: 0,
+            }),
+            end_time: Some(Timestamp {
+                seconds: end_time.timestamp(),
+                nanos: 0,
+            }),
+        }),
+        view: TimeSeriesView::Full.into(),
+        aggregation: Some(Aggregation {
+            alignment_period: Some(prost_types::Duration {
+                seconds: 600,
+                nanos: 0,
+            }),
+            per_series_aligner: Aligner::AlignMin as i32,
+            cross_series_reducer: Reducer::ReduceNone as i32,
+            group_by_fields: Vec::new(),
+        }),
+        secondary_aggregation: None,
+        order_by: "".to_string(),
+        page_size: 10,
+        page_token: "".to_string(),
     }
 }

--- a/sdk/src/services/gcloud/mod.rs
+++ b/sdk/src/services/gcloud/mod.rs
@@ -8,10 +8,16 @@ pub mod google {
         #[path = "google.logging.v2.rs"]
         pub mod v2;
     }
+    #[path = ""]
+    pub mod monitoring {
+        #[path = "google.monitoring.v3.rs"]
+        pub mod v3;
+    }
     #[path = "google.api.rs"]
     pub mod api;
     #[path = "google.rpc.rs"]
     pub mod rpc;
+
 }
 
 use self::google::logging::v2::{log_entry, LogEntry};


### PR DESCRIPTION
## Summary

In this PR we introduce a third panel called "Databases" that pulls metrics from GCloud using the protobuf generated modules by tonic for gcloud.
<img width="1659" alt="Screenshot 2024-03-06 at 4 30 57 PM" src="https://github.com/mindvalley/wukong-cli/assets/170094/66974191-4391-49a5-8580-4ff2969bf952">

Ticket: https://mindvalley.atlassian.net/browse/PXP-660

## What's Changed

<!-- ### Added -->
* Network dispatching of new get_database_metrics mechanism.

<!-- ### Changed -->
* Changed `Block::Log` to `Block::Middle`
<!-- ### Fixed -->
