### PR TITLE
PXP-676: [CLI] Skip workflow step on application init if empty

### DIFF
--- a/cli/src/commands/application/init.rs
+++ b/cli/src/commands/application/init.rs
@@ -37,7 +37,7 @@ pub async fn handle_application_init(context: Context) -> Result<bool, WKCliErro
     let workflows = get_workflows_from_current_dir()?;
     let mut excluded_workflows = Vec::new();
 
-    if let Some(workflows) = &workflows {
+    if !workflows.is_empty() {
         excluded_workflows = inquire::MultiSelect::new(
             "Workflows to exclude from the Wukong CLI & TUI",
             workflows.to_vec(),
@@ -265,7 +265,7 @@ async fn configure_namespace(
     })
 }
 
-fn get_workflows_from_current_dir() -> Result<Option<Vec<String>>, WKCliError> {
+fn get_workflows_from_current_dir() -> Result<Vec<String>, WKCliError> {
     let mut workflow_names = Vec::new();
 
     if let Ok(workflows) = fs::read_dir(".github/workflows") {
@@ -291,9 +291,7 @@ fn get_workflows_from_current_dir() -> Result<Option<Vec<String>>, WKCliError> {
                 }
             }
         }
-
-        Ok(Some(workflow_names))
-    } else {
-        Ok(None)
     }
+
+    Ok(workflow_names)
 }

--- a/cli/src/commands/application/init.rs
+++ b/cli/src/commands/application/init.rs
@@ -35,13 +35,19 @@ pub async fn handle_application_init(context: Context) -> Result<bool, WKCliErro
         .prompt()?;
 
     let workflows = get_workflows_from_current_dir()?;
-    let excluded_workflows =
-        inquire::MultiSelect::new("Workflows to exclude from the Wukong CLI & TUI", workflows)
-            .with_render_config(inquire_render_config())
-            .with_help_message(
-                "Leave blank to ignore, ↑↓ to move, space to select one, → to all, ← to none",
-            )
-            .prompt()?;
+    let mut excluded_workflows = Vec::new();
+
+    if let Some(workflows) = &workflows {
+        excluded_workflows = inquire::MultiSelect::new(
+            "Workflows to exclude from the Wukong CLI & TUI",
+            workflows.to_vec(),
+        )
+        .with_render_config(inquire_render_config())
+        .with_help_message(
+            "Leave blank to ignore, ↑↓ to move, space to select one, → to all, ← to none",
+        )
+        .prompt()?;
+    }
 
     let mut namespaces: Vec<ApplicationNamespaceConfig> = Vec::new();
     namespaces
@@ -259,32 +265,35 @@ async fn configure_namespace(
     })
 }
 
-fn get_workflows_from_current_dir() -> Result<Vec<String>, WKCliError> {
+fn get_workflows_from_current_dir() -> Result<Option<Vec<String>>, WKCliError> {
     let mut workflow_names = Vec::new();
-    let workflows = fs::read_dir(".github/workflows")?;
 
-    for workflow in workflows {
-        let workflow = workflow?;
+    if let Ok(workflows) = fs::read_dir(".github/workflows") {
+        for workflow in workflows {
+            let workflow = workflow?;
 
-        if workflow.file_type()?.is_file()
-            && workflow
-                .path()
-                .extension()
-                .map_or(false, |ext| ext == "yml" || ext == "yaml")
-        {
-            let workflow_content = fs::read_to_string(workflow.path())?;
-
-            let workflow_values: serde_yaml::Value = serde_yaml::from_str(&workflow_content)
-                .map_err(|_| WKCliError::UnableToParseYmlFile)?;
-
-            if let Some(workflow_name) = workflow_values
-                .get("name")
-                .and_then(serde_yaml::Value::as_str)
+            if workflow.file_type()?.is_file()
+                && workflow
+                    .path()
+                    .extension()
+                    .map_or(false, |ext| ext == "yml" || ext == "yaml")
             {
-                workflow_names.push(workflow_name.to_string());
+                let workflow_content = fs::read_to_string(workflow.path())?;
+
+                let workflow_values: serde_yaml::Value = serde_yaml::from_str(&workflow_content)
+                    .map_err(|_| WKCliError::UnableToParseYmlFile)?;
+
+                if let Some(workflow_name) = workflow_values
+                    .get("name")
+                    .and_then(serde_yaml::Value::as_str)
+                {
+                    workflow_names.push(workflow_name.to_string());
+                }
             }
         }
-    }
 
-    Ok(workflow_names)
+        Ok(Some(workflow_names))
+    } else {
+        Ok(None)
+    }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary
Currently, when running the application init, if there are no Github Actions workflows in the .github folder, the CLI will return error. To handle this case skip the workflow action if there is no file in the directly or path is not found

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: [PXP-676](https://mindvalley.atlassian.net/browse/PXP-676)

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

 ### Changed 

- [x] Skip workflow selection if yaml file is not found in the .github directory
- [x] Skip workflow selection if .github file is not found

<!-- ### Fixed -->


[PXP-676]: https://mindvalley.atlassian.net/browse/PXP-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ