### PR TITLE
fix: handle an issue where namespace casting is Capital case instead …

### DIFF
--- a/cli/src/commands/application/mod.rs
+++ b/cli/src/commands/application/mod.rs
@@ -72,10 +72,10 @@ impl Display for ApplicationVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ApplicationVersion::Blue => {
-                write!(f, "Blue")
+                write!(f, "blue")
             }
             ApplicationVersion::Green => {
-                write!(f, "Green")
+                write!(f, "green")
             }
         }
     }
@@ -91,10 +91,10 @@ impl Display for ApplicationNamespace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ApplicationNamespace::Prod => {
-                write!(f, "Prod")
+                write!(f, "prod")
             }
             ApplicationNamespace::Staging => {
-                write!(f, "Staging")
+                write!(f, "staging")
             }
         }
     }

--- a/cli/src/commands/tui/app.rs
+++ b/cli/src/commands/tui/app.rs
@@ -123,6 +123,7 @@ pub const MAX_LOG_ENTRIES_LENGTH: usize = 2_000;
 
 #[derive(Debug, Default)]
 pub struct DatabasesState {
+    #[allow(dead_code)]
     pub is_active: bool,
     pub error: Option<String>,
     pub database_metrics: Vec<DatabaseMetrics>,
@@ -132,6 +133,7 @@ pub struct State {
     pub current_namespace: Option<String>,
     pub current_version: Option<String>,
     pub current_time_filter: Option<TimeFilter>,
+    #[allow(dead_code)]
     pub show_namespace_selection: bool,
 
     // appsignal config
@@ -167,6 +169,7 @@ pub struct State {
     pub is_okta_authenticated: Option<bool>,
 
     pub last_log_entry_timestamp: Option<String>,
+    #[allow(dead_code)]
     pub log_time_filter: TimeFilter,
     // ui controls
     pub logs_vertical_scroll_state: ScrollbarState,
@@ -210,6 +213,7 @@ pub struct App {
     pub state: State,
     pub namespace_selections: StatefulList<String>,
     pub version_selections: StatefulList<String>,
+    #[allow(dead_code)]
     pub time_filter_selections: StatefulList<TimeFilter>,
     pub actions: Vec<Action>,
     pub network_event_sender: Sender<NetworkEvent>,
@@ -228,6 +232,7 @@ pub struct Commit {
 }
 
 pub struct Deployment {
+    #[allow(dead_code)]
     pub name: String,
     pub environment: String,
     pub version: String,

--- a/cli/tests/snapshots/application_instances__wukong_application_instances_list_success.snap
+++ b/cli/tests/snapshots/application_instances__wukong_application_instances_list_success.snap
@@ -5,7 +5,7 @@ expression: "std::str::from_utf8(&output.stdout).unwrap()"
 ┌───────────────────────┬─────────────┬────────────────┬──────────────────────┐
 │ INSTANCE-NAME         │ INSTANCE-IP │ INSTANCE-READY │ IS_LIVEBOOK_INSTANCE │
 ├───────────────────────┼─────────────┼────────────────┼──────────────────────┤
-│ Green@Prod/the-blue-1 │             │ true           │ false                │
+│ green@prod/the-blue-1 │             │ true           │ false                │
 ├───────────────────────┼─────────────┼────────────────┼──────────────────────┤
-│ Green@Prod/the-blue-2 │             │ false          │ false                │
+│ green@prod/the-blue-2 │             │ false          │ false                │
 └───────────────────────┴─────────────┴────────────────┴──────────────────────┘


### PR DESCRIPTION
## Summary
This PR addresses an issue introduced in our previous [PR](https://github.com/mindvalley/wukong-cli/pull/217/files) due to the forced migration to `to_string_trait_impl` with the new Rust version. During this migration, all display calls were replaced with `write!(f, "prod")`. However, an error was made by mistakenly using an titlecase instead of the lowercase.

This update corrects the casing error to ensure the accurate representation of the string in all relevant locations.

## What's Changed

- [x] Corrected the string "Prod" to "prod" in all instances of write!(f, "Prod") to write!(f, "prod")
- [x] Corrected the string "Staging" to "staging" in all instances of write!(f, "Prod") to write!(f, "prod").
- [x] Corrected the string "Green" to "green" in all instances of write!(f, "Green") to write!(f, "green").
- [x] Corrected the string "Blue" to "blue" in all instances of write!(f, "Blue") to write!(f, "blue").

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: -

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

<!-- ### Fixed -->
