### PR TITLE
DX-805 get and show pod connection details for livebook smart cell

### DIFF
--- a/cli/src/commands/application/instances/connect.rs
+++ b/cli/src/commands/application/instances/connect.rs
@@ -282,13 +282,13 @@ pub async fn handle_connect(
         ) {
             (Some(node_name), Some(pod_ip), Some(cookie)) => {
                 eprintln!("To connect to mv-wukong-api-proxy:");
-                eprintln!("\t1. start a new Notebook");
-                eprintln!("\t2. click on `+Smart`");
-                eprintln!("\t3. select `Remote Execution`");
-                eprintln!("\t4. follow the instructions that pop up to restart the Notebook");
-                eprintln!("\t5. enter these values into the `NODE` and `COOKIE` input boxes:");
-                eprintln!("\t\tNODE: 🖥️: {}@{}", node_name.cyan(), pod_ip.cyan());
-                eprintln!("\t\tCOOKIE: 🍪: {}", cookie.yellow());
+                eprintln!("  1. start a new Notebook");
+                eprintln!("  2. click on `+Smart`");
+                eprintln!("  3. select `Remote Execution`");
+                eprintln!("  4. follow the instructions that pop up to restart the Notebook");
+                eprintln!("  5. enter these values into the `NODE` and `COOKIE` input boxes:");
+                eprintln!("    NODE: 🖥️: {}@{}", node_name.cyan(), pod_ip.cyan());
+                eprintln!("    COOKIE: 🍪: {}", cookie.yellow());
                 eprintln!();
             }
             (None, ..) => {

--- a/cli/src/commands/application/instances/connect.rs
+++ b/cli/src/commands/application/instances/connect.rs
@@ -281,12 +281,15 @@ pub async fn handle_connect(
             &instance_object.cookie,
         ) {
             (Some(node_name), Some(pod_ip), Some(cookie)) => {
-                eprintln!(
-                    "To connect to mv-wukong-api-proxy, start a new Notebook and click on `+Smart`\nand select `Remote Execution`. Follow the instructions that pop up to restart the Notebook.\nEnter these values into the `NODE` and `COOKIE` input boxes:"
-                );
+                eprintln!("To connect to mv-wukong-api-proxy:");
+                eprintln!("\t1. start a new Notebook");
+                eprintln!("\t2. click on `+Smart`");
+                eprintln!("\t3. select `Remote Execution`");
+                eprintln!("\t4. follow the instructions that pop up to restart the Notebook");
+                eprintln!("\t5. enter these values into the `NODE` and `COOKIE` input boxes:");
+                eprintln!("\t\tNODE: 🖥️: {}@{}", node_name.cyan(), pod_ip.cyan());
+                eprintln!("\t\tCOOKIE: 🍪: {}", cookie.yellow());
                 eprintln!();
-                eprintln!("NODE: 🖥️: {}@{}", node_name.cyan(), pod_ip.cyan());
-                eprintln!("COOKIE: 🍪: {}", cookie.yellow());
             }
             (None, ..) => {
                 eprintln!("We were unable to determine the node name for the app node you wish to connect to. Please contact your administrator for assistance.")

--- a/cli/src/commands/application/instances/connect.rs
+++ b/cli/src/commands/application/instances/connect.rs
@@ -315,9 +315,8 @@ pub async fn handle_connect(
         let _ = wk_client
             .destroy_livebook(&application, &namespace, &version)
             .await
-            .map_err(|err| {
+            .inspect_err(|_err| {
                 eprintln!("Failed to destroy the livebook instance.");
-                err
             })?;
 
         exiting_loader.finish_and_clear();

--- a/cli/src/commands/application/instances/connect.rs
+++ b/cli/src/commands/application/instances/connect.rs
@@ -34,6 +34,9 @@ struct Status {
 struct KubernetesPod {
     name: String,
     ready: bool,
+    pod_ip: Option<String>,
+    node_name: Option<String>,
+    cookie: Option<String>,
     is_livebook: Option<bool>,
 }
 
@@ -142,6 +145,7 @@ pub async fn handle_connect(
         .interact()?;
 
     let instance_name = k8s_pods[instance_name_idx].name.clone();
+    let instance_object = &k8s_pods[instance_name_idx];
 
     let preparing_loader = new_spinner();
     preparing_loader.set_style(spinner_style.clone());
@@ -271,6 +275,33 @@ pub async fn handle_connect(
         );
         eprintln!();
 
+        match (
+            &instance_object.node_name,
+            &instance_object.pod_ip,
+            &instance_object.cookie,
+        ) {
+            (Some(node_name), Some(pod_ip), Some(cookie)) => {
+                eprintln!(
+                    "To connect to mv-wukong-api-proxy, start a new Notebook and click on `+Smart`\nand select `Remote Execution`. Follow the instructions that pop up to restart the Notebook.\nEnter these values into the `NODE` and `COOKIE` input boxes:"
+                );
+                eprintln!();
+                eprintln!("NODE: 🖥️: {}@{}", node_name.cyan(), pod_ip.cyan());
+                eprintln!("COOKIE: 🍪: {}", cookie.yellow());
+            }
+            (None, ..) => {
+                eprintln!("We were unable to determine the node name for the app node you wish to connect to. Please contact your administrator for assistance.")
+            }
+            (_, None, _) => {
+                eprintln!("We were unable to determine the ip for the app node you wish to connect to. Please contact your administrator for assistance.")
+            }
+            (.., None) => {
+                eprintln!("We were unable to determine the cookie for the app node you wish to connect to. Please contact your administrator for assistance.")
+            }
+        }
+
+        eprintln!();
+        eprintln!();
+
         let running_loader = new_spinner();
         running_loader
             .set_message("Your livebook instance is running. Press Ctrl-C to terminate...");
@@ -369,6 +400,9 @@ async fn get_ready_k8s_pods(
         .map(|pod| KubernetesPod {
             name: pod.name,
             ready: pod.ready,
+            pod_ip: pod.pod_ip,
+            node_name: pod.node_name,
+            cookie: pod.cookie,
             is_livebook: Some(pod.labels.contains(&"livebook".to_string())),
         })
         .filter(|pod| pod.ready && !pod.is_livebook.unwrap_or_default())

--- a/sdk/src/graphql/query/kubernetes_pods.graphql
+++ b/sdk/src/graphql/query/kubernetes_pods.graphql
@@ -10,7 +10,10 @@ query KubernetesPodsQuery(
   ) {
     name
     podIp
+    nodeName
+    cookie
     ready
     labels
+
   }
 }

--- a/sdk/src/graphql/schema.json
+++ b/sdk/src/graphql/schema.json
@@ -3402,6 +3402,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "nodeName",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cookie",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "podState",
               "type": {
                 "kind": "SCALAR",

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -115,10 +115,7 @@ impl Telemetry {
         let telemetry_data = {
             let content = std::fs::read_to_string(telemetry_file_path);
             match content {
-                Ok(data) => match serde_json::from_str::<Vec<TelemetryData>>(&data) {
-                    Ok(data) => data,
-                    Err(_) => Vec::new(),
-                },
+                Ok(data) => serde_json::from_str::<Vec<TelemetryData>>(&data).unwrap_or_default(),
                 Err(_) => Vec::new(),
             }
         };


### PR DESCRIPTION
## Summary

In this PR, we update the kubernetes_pod query to additionally get the `node_name` and `cookie` for the pod and display those values along with a short instruction on how the user can connect to a selected node.

Ticket: [DX-805](https://mindvalley.atlassian.net/browse/DX-805)

The changes in action:

<img width="1018" alt="Screenshot 2024-10-01 at 3 35 16 PM" src="https://github.com/user-attachments/assets/eee2f737-0b6d-4b22-8820-01e1cc4f96a0">


Testing out the provided details in a livebook:
<img width="974" alt="Screenshot 2024-09-30 at 6 58 57 PM" src="https://github.com/user-attachments/assets/05110a39-de7c-4918-8c31-56cc27ca2f6a">


## What's Changed

<!-- ### Added -->
Show pod connection details and instructions on how to use them in the `application instances connect` flow

<!-- ### Changed -->
Updated schema and kubernetes_pods.graphql to get `node_name` and `cookie` 



[DX-805]: https://mindvalley.atlassian.net/browse/DX-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ