### PR TITLE
feat: group pods by main or preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.81.0
           components: rustfmt, clippy
 
       - name: Check formatting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           target: ${{ matrix.job.target }}
           components: rustfmt, clippy
+          toolchain: 1.81.0
 
       - name: Install protoc for Linux
         if: contains(matrix.job.target, 'linux')

--- a/cli/src/commands/application/instances/connect.rs
+++ b/cli/src/commands/application/instances/connect.rs
@@ -173,10 +173,15 @@ pub async fn handle_connect(
     let instance_name = if instance_name_idx < main_pods.len() + 1 {
         main_pods[instance_name_idx - 1].name.clone()
     } else {
-        preview_pods[instance_name_idx - main_pods.len() - 2].name.clone()
+        preview_pods[instance_name_idx - main_pods.len() - 2]
+            .name
+            .clone()
     };
 
-    let instance_object = k8s_pods.iter().find(|pod| pod.name == instance_name).unwrap();
+    let instance_object = k8s_pods
+        .iter()
+        .find(|pod| pod.name == instance_name)
+        .unwrap();
 
     let preparing_loader = new_spinner();
     preparing_loader.set_style(spinner_style.clone());

--- a/cli/src/commands/application/instances/connect.rs
+++ b/cli/src/commands/application/instances/connect.rs
@@ -31,6 +31,7 @@ struct Status {
     service: bool,
 }
 
+#[derive(Debug)]
 struct KubernetesPod {
     name: String,
     ready: bool,
@@ -38,6 +39,7 @@ struct KubernetesPod {
     node_name: Option<String>,
     cookie: Option<String>,
     is_livebook: Option<bool>,
+    is_preview: Option<bool>,
 }
 
 #[wukong_telemetry(command_event = "application_instances_connect")]
@@ -121,31 +123,60 @@ pub async fn handle_connect(
 
     let k8s_pods = get_ready_k8s_pods(&mut wk_client, &application, &namespace, &version).await?;
 
-    debug!("Found {} pods", k8s_pods.len());
     if k8s_pods.is_empty() {
         eprintln!("Found 0 instances. Either there's no running instances, or the instances are not ready to connect to using Livebook remote shell.");
 
         return Ok(false);
     }
 
+    let main_pods = k8s_pods
+        .iter()
+        .filter(|pod| !pod.is_preview.unwrap_or_default())
+        .collect::<Vec<&KubernetesPod>>();
+
+    let preview_pods = k8s_pods
+        .iter()
+        .filter(|pod| pod.is_preview.unwrap_or_default())
+        .collect::<Vec<&KubernetesPod>>();
+
     fetch_instance_loader.finish_with_message(format!(
         "Finding the available instances to connect to in the {} version...✅",
         version.bright_green()
     ));
 
-    let instance_name_idx = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Please choose the instance you want to connect")
-        .default(0)
-        .items(
-            &k8s_pods
-                .iter()
-                .map(|pod| pod.name.clone())
-                .collect::<Vec<String>>(),
-        )
-        .interact()?;
+    let mut items = Vec::new();
+    if !main_pods.is_empty() {
+        items.push("Main:".to_string());
+        items.extend(main_pods.iter().map(|pod| format!("  {}", pod.name)));
+    }
+    if !preview_pods.is_empty() {
+        items.push("Preview:".to_string());
+        items.extend(preview_pods.iter().map(|pod| format!("  {}", pod.name)));
+    }
 
-    let instance_name = k8s_pods[instance_name_idx].name.clone();
-    let instance_object = &k8s_pods[instance_name_idx];
+    let instance_name_idx = loop {
+        let instance_name_idx = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("Please choose the instance you want to connect")
+            .default(0)
+            .items(&items)
+            .interact()?;
+
+        if instance_name_idx == 0 || instance_name_idx == main_pods.len() + 1 {
+            // If "Main pods" or "Preview pods" is selected, continue the loop
+            continue;
+        } else {
+            // Otherwise, break the loop and return the selected index
+            break instance_name_idx;
+        }
+    };
+
+    let instance_name = if instance_name_idx < main_pods.len() + 1 {
+        main_pods[instance_name_idx - 1].name.clone()
+    } else {
+        preview_pods[instance_name_idx - main_pods.len() - 2].name.clone()
+    };
+
+    let instance_object = k8s_pods.iter().find(|pod| pod.name == instance_name).unwrap();
 
     let preparing_loader = new_spinner();
     preparing_loader.set_style(spinner_style.clone());
@@ -406,6 +437,7 @@ async fn get_ready_k8s_pods(
             node_name: pod.node_name,
             cookie: pod.cookie,
             is_livebook: Some(pod.labels.contains(&"livebook".to_string())),
+            is_preview: Some(pod.labels.contains(&"preview".to_string())),
         })
         .filter(|pod| pod.ready && !pod.is_livebook.unwrap_or_default())
         .collect();

--- a/cli/src/commands/application/instances/connect.rs
+++ b/cli/src/commands/application/instances/connect.rs
@@ -31,7 +31,6 @@ struct Status {
     service: bool,
 }
 
-#[derive(Debug)]
 struct KubernetesPod {
     name: String,
     ready: bool,


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In this PR, we present the connectable instances in `application instances connect` in groups of "Main" or "Preview Instances".

Selecting either "Main" or "Preview" just keeps the user in the select context. User can only move forward by selecting one of the instances.
<img width="772" alt="Screenshot 2024-11-01 at 2 53 35 PM" src="https://github.com/user-attachments/assets/7371cdcc-d913-4bbb-a863-fcfb291de37a">
<img width="731" alt="Screenshot 2024-11-01 at 2 33 08 PM" src="https://github.com/user-attachments/assets/7baa8245-620b-4a68-9119-969c3ff411e0">


<!-- Link any relevant issues or Jira ticket if necessary -->

Ticket: https://mindvalley.atlassian.net/browse/DX-831

## What's Changed

<!-- Explain what is changed in this pull request -->

<!-- ### Added -->

<!-- ### Changed -->

Updated the `application instances connect` Select menu to display pods grouped by "is_preview"

<!-- ### Fixed -->
