### PR TITLE
Add continuous delivery flag to wukong init command

### DIFF
--- a/cli/src/application_config.rs
+++ b/cli/src/application_config.rs
@@ -27,6 +27,8 @@ pub struct ApplicationNamespaceConfig {
     pub honeycomb: Option<ApplicationNamespaceHoneycombConfig>,
     pub cloudsql: Option<ApplicationNamespaceCloudsqlConfig>,
     pub notifications: Option<ApplicationNamespaceNotificationsConfig>,
+    /// The `continuous_delivery` flag indicates whether continuous delivery is enabled for the namespace.
+    pub continuous_delivery: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]

--- a/cli/src/commands/application/init.rs
+++ b/cli/src/commands/application/init.rs
@@ -108,7 +108,7 @@ pub async fn handle_application_init(context: Context) -> Result<bool, WKCliErro
     let workflows = get_workflows_from_current_dir()?;
     let mut excluded_workflows = Vec::new();
 
-    if !workflows.is_empty() {
+    if (!workflows.is_empty()) {
         excluded_workflows = inquire::MultiSelect::new(
             "Workflows to exclude from the Wukong CLI & TUI",
             workflows.to_vec(),
@@ -385,6 +385,11 @@ async fn configure_namespace(
         .with_help_message("Leave it blank to disable Slack notifications. Use 'channel-name' format without the '#'. \n\nIt is your responsibility to ensure the channel name exists, and to add the bot integration if the channel is private.")
         .prompt()?;
 
+    let continuous_delivery = inquire::Confirm::new("Do you want to enable continuous delivery?")
+        .with_render_config(inquire_render_config())
+        .with_default(false)
+        .prompt()?;
+
     Ok(ApplicationNamespaceConfig {
         namespace_type: namespace_type.clone(),
         build: build_workflow.map(|workflow| ApplicationNamespaceBuildConfig {
@@ -441,6 +446,7 @@ async fn configure_namespace(
                 }),
             })
         },
+        continuous_delivery,
     })
 }
 


### PR DESCRIPTION
Add prompt for `continuous_delivery` flag in `wukong init` command and save selection in `wukong.toml`.

* **cli/src/application_config.rs**
  - Add `continuous_delivery` field to `ApplicationNamespaceConfig` struct as a boolean.
  - Provide a brief description of the `continuous_delivery` flag in the comments above the `ApplicationNamespaceConfig` struct.

* **cli/src/commands/application/init.rs**
  - Add prompt for `continuous_delivery` flag in `configure_namespace` function.
  - Include `continuous_delivery` flag in the namespace configuration based on user input.
  - Update the generated `wukong.toml` file to include the `continuous_delivery` flag.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mindvalley/wukong-cli/pull/233?shareId=d139318d-5475-4b22-8d6d-33d99bf9b9c4).