### PR TITLE
Add wukong secrets provider for dev config pull/diff/push

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "wukong"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "aion",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wukong"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2021"
 default-run = "wukong"
 

--- a/cli/src/commands/application/init.rs
+++ b/cli/src/commands/application/init.rs
@@ -108,7 +108,7 @@ pub async fn handle_application_init(context: Context) -> Result<bool, WKCliErro
     let workflows = get_workflows_from_current_dir()?;
     let mut excluded_workflows = Vec::new();
 
-    if (!workflows.is_empty()) {
+    if !workflows.is_empty() {
         excluded_workflows = inquire::MultiSelect::new(
             "Workflows to exclude from the Wukong CLI & TUI",
             workflows.to_vec(),

--- a/cli/src/commands/dev/config/diff.rs
+++ b/cli/src/commands/dev/config/diff.rs
@@ -1,8 +1,8 @@
 use super::utils::{
     extract_secret_infos, get_local_config_path, get_secret_config_files, get_updated_configs,
+    vault_token_for,
 };
 use crate::{
-    auth::vault,
     commands::{dev::config::utils::make_path_relative, Context},
     config::Config,
     error::{DevConfigError, WKCliError},
@@ -38,13 +38,14 @@ pub async fn handle_config_diff(context: Context) -> Result<bool, WKCliError> {
     }
 
     let mut config = Config::load_from_default_path()?;
-    let wk_client = WKClient::for_channel(&config, &context.channel)?;
-    let vault_token = vault::get_token_or_login(&mut config).await?;
+    let mut wk_client = WKClient::for_channel(&config, &context.channel)?;
+    let vault_token = vault_token_for(&extracted_infos, &mut config).await?;
 
-    let updated_configs = get_updated_configs(&wk_client, &vault_token, &extracted_infos).await?;
+    let updated_configs =
+        get_updated_configs(&mut wk_client, &vault_token, &extracted_infos).await?;
 
     if updated_configs.is_empty() {
-        println!("The config file is already up to date with the Vault Bunker.");
+        println!("The config file is already up to date with the remote.");
         return Ok(true);
     }
 

--- a/cli/src/commands/dev/config/pull.rs
+++ b/cli/src/commands/dev/config/pull.rs
@@ -17,7 +17,9 @@ use crate::{
     wukong_client::WKClient,
 };
 
-use super::utils::{extract_secret_infos, get_secret_config_files, parse_wukong_src, vault_token_for};
+use super::utils::{
+    extract_secret_infos, get_secret_config_files, parse_wukong_src, vault_token_for,
+};
 use wukong_telemetry::*;
 use wukong_telemetry_macro::*;
 

--- a/cli/src/commands/dev/config/pull.rs
+++ b/cli/src/commands/dev/config/pull.rs
@@ -1,9 +1,9 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     env::current_dir,
-    fs::File,
+    fs::{File, OpenOptions},
     io::{ErrorKind, Write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use log::debug;
@@ -17,11 +17,19 @@ use crate::{
     wukong_client::WKClient,
 };
 
+use super::diff::has_diff;
 use super::utils::{
     extract_secret_infos, get_secret_config_files, parse_wukong_src, vault_token_for,
 };
 use wukong_telemetry::*;
 use wukong_telemetry_macro::*;
+
+/// Suffix appended to the original filename when a pull would overwrite it.
+const BACKUP_SUFFIX: &str = ".bak";
+
+/// Pattern we ensure is present in `.gitignore` so backups never get
+/// accidentally committed.
+const BACKUP_GITIGNORE_PATTERN: &str = "*.bak";
 
 #[wukong_telemetry(command_event = "dev_config_pull")]
 pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, WKCliError> {
@@ -48,6 +56,9 @@ pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, W
 
     let mut has_error = false;
     let mut secrets_cache: HashMap<(String, String), FetchSecretsData> = HashMap::new();
+    // Tracks which `.gitignore` files we've already touched this run so we
+    // don't re-read/append them per annotation.
+    let mut gitignored_dirs: HashSet<PathBuf> = HashSet::new();
 
     for info in extracted_infos {
         eprintln!();
@@ -141,6 +152,19 @@ pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, W
                 };
             }
 
+            // Snapshot the previous version before we overwrite it, but only
+            // when the file actually exists and its content differs from what
+            // we're about to write. First-pull (file absent) and no-op pull
+            // (identical content) both skip backup.
+            if let Some(backup_path) = backup_existing_if_changed(&file_path, &secret) {
+                eprintln!(
+                    "\t{} {}",
+                    "📦 Backed up previous version to".cyan(),
+                    backup_path.to_string_lossy()
+                );
+                ensure_backup_gitignored(&file_path, &info.0, &mut gitignored_dirs);
+            }
+
             match File::create(&file_path) {
                 Ok(mut file) => {
                     if let Err(err) = file.write_all(secret.as_bytes()) {
@@ -178,5 +202,328 @@ pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, W
         Ok(false)
     } else {
         Ok(true)
+    }
+}
+
+/// If `file_path` already exists and its content differs from `incoming`,
+/// copy it to a sibling `<name>.bak` (overwriting any prior backup) and
+/// return that path. Otherwise return `None` and write nothing.
+///
+/// Errors during read/write are logged and treated as "no backup" — we never
+/// abort the pull just because a backup attempt failed.
+fn backup_existing_if_changed(file_path: &Path, incoming: &str) -> Option<PathBuf> {
+    let existing = match std::fs::read_to_string(file_path) {
+        Ok(content) => content,
+        // Includes the file-not-found case (first pull) and any other read
+        // failure. We don't try to distinguish — both mean "no backup needed
+        // or possible".
+        Err(err) => {
+            debug!(
+                "skipping backup of {}: {:?}",
+                file_path.to_string_lossy(),
+                err
+            );
+            return None;
+        }
+    };
+
+    if !has_diff(&existing, incoming) {
+        return None;
+    }
+
+    // Build the backup path via OsString so non-UTF-8 filenames survive.
+    let mut name = file_path.file_name()?.to_os_string();
+    name.push(BACKUP_SUFFIX);
+    let backup = file_path.with_file_name(name);
+
+    if let Err(err) = std::fs::copy(file_path, &backup) {
+        debug!(
+            "failed to write backup {}: {:?}",
+            backup.to_string_lossy(),
+            err
+        );
+        return None;
+    }
+
+    Some(backup)
+}
+
+/// Append `*.bak` to the nearest `.gitignore` (walking up from the
+/// destination file, stopping at the directory containing the annotated
+/// config). If no `.gitignore` exists along that chain, create one next to
+/// the annotated config. Idempotent across the run via `seen_dirs`, and
+/// idempotent across runs via a per-line check.
+fn ensure_backup_gitignored(
+    file_path: &Path,
+    annotated_config_path: &str,
+    seen_dirs: &mut HashSet<PathBuf>,
+) {
+    let config_dir = match Path::new(annotated_config_path).parent() {
+        Some(p) => p.to_path_buf(),
+        None => return,
+    };
+
+    let target = find_gitignore_target(file_path, &config_dir);
+
+    if !seen_dirs.insert(target.clone()) {
+        return;
+    }
+
+    // Single read covers both the presence check and the trailing-newline
+    // decision below. Missing file → empty string, which means "create".
+    let content = std::fs::read_to_string(&target).unwrap_or_default();
+    if content
+        .lines()
+        .any(|line| line.trim() == BACKUP_GITIGNORE_PATTERN)
+    {
+        return;
+    }
+
+    let result = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&target)
+        .and_then(|mut f| {
+            // Avoid running the new pattern onto the previous line when the
+            // existing file lacks a trailing newline. An empty file gets no
+            // leading newline.
+            let needs_separator = !content.is_empty() && !content.ends_with('\n');
+            let prefix = if needs_separator { "\n" } else { "" };
+            writeln!(f, "{}{}", prefix, BACKUP_GITIGNORE_PATTERN)
+        });
+
+    match result {
+        Ok(_) => eprintln!(
+            "\t{} {} {}",
+            "🔒 Added".cyan(),
+            BACKUP_GITIGNORE_PATTERN.bold(),
+            format!("to {}", target.to_string_lossy()).cyan()
+        ),
+        Err(err) => debug!("failed to update {}: {:?}", target.to_string_lossy(), err),
+    }
+}
+
+/// Walk upward from `file_path`'s directory until we find an existing
+/// `.gitignore`, stopping at `config_dir`. If none is found (or if the file
+/// somehow lives outside `config_dir`), fall back to creating one in
+/// `config_dir` itself — we never modify a `.gitignore` above the project's
+/// annotated-config root.
+fn find_gitignore_target(file_path: &Path, config_dir: &Path) -> PathBuf {
+    let start = file_path.parent().unwrap_or(config_dir);
+
+    // Defensive: if the destination resolves outside the config root, don't
+    // walk up arbitrary filesystem ancestors looking for a `.gitignore`.
+    if !start.starts_with(config_dir) {
+        return config_dir.join(".gitignore");
+    }
+
+    let mut cursor = Some(start);
+    while let Some(dir) = cursor {
+        let candidate = dir.join(".gitignore");
+        if candidate.exists() {
+            return candidate;
+        }
+        if dir == config_dir {
+            break;
+        }
+        cursor = dir.parent();
+    }
+
+    config_dir.join(".gitignore")
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use assert_fs::prelude::{FileWriteStr, PathChild};
+
+    #[test]
+    fn no_backup_when_file_absent() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let target = dir.child(".env");
+        assert!(backup_existing_if_changed(target.path(), "fresh content").is_none());
+        assert!(!dir.child(".env.bak").path().exists());
+    }
+
+    #[test]
+    fn no_backup_when_content_unchanged() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let target = dir.child(".env");
+        target.write_str("FOO=bar\n").unwrap();
+        assert!(backup_existing_if_changed(target.path(), "FOO=bar\n").is_none());
+        assert!(!dir.child(".env.bak").path().exists());
+    }
+
+    #[test]
+    fn backup_written_when_content_differs() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let target = dir.child(".env");
+        target.write_str("FOO=old\n").unwrap();
+
+        let backup = backup_existing_if_changed(target.path(), "FOO=new\n").unwrap();
+        assert_eq!(backup, dir.child(".env.bak").path());
+
+        let backup_content = std::fs::read_to_string(&backup).unwrap();
+        assert_eq!(backup_content, "FOO=old\n");
+    }
+
+    #[test]
+    fn backup_overwrites_previous_backup() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let target = dir.child(".env");
+        let prior_backup = dir.child(".env.bak");
+        target.write_str("v2\n").unwrap();
+        prior_backup.write_str("v0\n").unwrap();
+
+        let backup = backup_existing_if_changed(target.path(), "v3\n").unwrap();
+        let content = std::fs::read_to_string(&backup).unwrap();
+        // The new backup is the v2 (current), not the stale v0.
+        assert_eq!(content, "v2\n");
+    }
+
+    #[test]
+    fn gitignore_appended_with_separator_when_no_trailing_newline() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let config_path = dir.child(".wukong.toml");
+        config_path.write_str("").unwrap();
+        let gitignore = dir.child(".gitignore");
+        // Existing content with no trailing newline.
+        gitignore.write_str("node_modules").unwrap();
+        let env_path = dir.child(".env");
+
+        let mut seen = HashSet::new();
+        ensure_backup_gitignored(
+            env_path.path(),
+            &config_path.path().to_string_lossy(),
+            &mut seen,
+        );
+
+        let content = std::fs::read_to_string(gitignore.path()).unwrap();
+        // Should be `node_modules\n*.bak\n`, not `node_modules*.bak\n`.
+        assert_eq!(content, "node_modules\n*.bak\n");
+    }
+
+    #[test]
+    fn find_gitignore_falls_back_when_dest_outside_config_dir() {
+        let outer = assert_fs::TempDir::new().unwrap();
+        let config_dir = outer.child("project");
+        std::fs::create_dir_all(config_dir.path()).unwrap();
+        // A file living outside the project root (e.g. someone abusing `..`).
+        let escaped = outer.child("escape/.env");
+
+        let target = find_gitignore_target(escaped.path(), config_dir.path());
+        // Must NOT walk up into `outer` looking for a .gitignore — must
+        // fall back to the project root.
+        assert_eq!(target, config_dir.child(".gitignore").path());
+    }
+
+    #[test]
+    fn gitignore_created_when_missing() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let config_path = dir.child(".wukong.toml");
+        config_path.write_str("").unwrap();
+        let env_path = dir.child(".env");
+
+        let mut seen = HashSet::new();
+        ensure_backup_gitignored(
+            env_path.path(),
+            &config_path.path().to_string_lossy(),
+            &mut seen,
+        );
+
+        let gitignore = dir.child(".gitignore");
+        assert!(gitignore.path().exists());
+        let content = std::fs::read_to_string(gitignore.path()).unwrap();
+        assert!(content.contains(BACKUP_GITIGNORE_PATTERN));
+    }
+
+    #[test]
+    fn gitignore_appended_when_pattern_missing() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let config_path = dir.child(".wukong.toml");
+        config_path.write_str("").unwrap();
+        let gitignore = dir.child(".gitignore");
+        gitignore.write_str("node_modules\n").unwrap();
+        let env_path = dir.child(".env");
+
+        let mut seen = HashSet::new();
+        ensure_backup_gitignored(
+            env_path.path(),
+            &config_path.path().to_string_lossy(),
+            &mut seen,
+        );
+
+        let content = std::fs::read_to_string(gitignore.path()).unwrap();
+        assert!(content.contains("node_modules"));
+        assert!(content.contains(BACKUP_GITIGNORE_PATTERN));
+    }
+
+    #[test]
+    fn gitignore_not_modified_when_pattern_present() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let config_path = dir.child(".wukong.toml");
+        config_path.write_str("").unwrap();
+        let gitignore = dir.child(".gitignore");
+        let original = format!("node_modules\n{}\n", BACKUP_GITIGNORE_PATTERN);
+        gitignore.write_str(&original).unwrap();
+        let env_path = dir.child(".env");
+
+        let mut seen = HashSet::new();
+        ensure_backup_gitignored(
+            env_path.path(),
+            &config_path.path().to_string_lossy(),
+            &mut seen,
+        );
+
+        let content = std::fs::read_to_string(gitignore.path()).unwrap();
+        assert_eq!(content, original);
+    }
+
+    #[test]
+    fn gitignore_only_touched_once_per_run() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let config_path = dir.child(".wukong.toml");
+        config_path.write_str("").unwrap();
+        let env_path = dir.child(".env");
+
+        let mut seen = HashSet::new();
+        ensure_backup_gitignored(
+            env_path.path(),
+            &config_path.path().to_string_lossy(),
+            &mut seen,
+        );
+        // Simulate a second annotation in the same run.
+        let other_path = dir.child(".env.local");
+        ensure_backup_gitignored(
+            other_path.path(),
+            &config_path.path().to_string_lossy(),
+            &mut seen,
+        );
+
+        let content = std::fs::read_to_string(dir.child(".gitignore").path()).unwrap();
+        let occurrences = content.matches(BACKUP_GITIGNORE_PATTERN).count();
+        assert_eq!(occurrences, 1);
+    }
+
+    #[test]
+    fn find_gitignore_walks_up_to_existing() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let config_path = dir.child(".wukong.toml");
+        config_path.write_str("").unwrap();
+        let root_gitignore = dir.child(".gitignore");
+        root_gitignore.write_str("").unwrap();
+
+        // Destination is nested 2 dirs deep; should resolve to the root .gitignore.
+        let nested = dir.child("priv/files/kubeconfig");
+        let target = find_gitignore_target(nested.path(), dir.path());
+        assert_eq!(target, root_gitignore.path());
+    }
+
+    #[test]
+    fn find_gitignore_falls_back_to_config_dir() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let nested = dir.child("priv/files/kubeconfig");
+        let target = find_gitignore_target(nested.path(), dir.path());
+        assert_eq!(target, dir.child(".gitignore").path());
     }
 }

--- a/cli/src/commands/dev/config/pull.rs
+++ b/cli/src/commands/dev/config/pull.rs
@@ -11,14 +11,13 @@ use owo_colors::OwoColorize;
 use wukong_sdk::services::vault::client::FetchSecretsData;
 
 use crate::{
-    auth::vault,
     commands::{dev::config::utils::get_local_config_path, Context},
     config::Config,
     error::WKCliError,
     wukong_client::WKClient,
 };
 
-use super::utils::{extract_secret_infos, get_secret_config_files};
+use super::utils::{extract_secret_infos, get_secret_config_files, parse_wukong_src, vault_token_for};
 use wukong_telemetry::*;
 use wukong_telemetry_macro::*;
 
@@ -42,11 +41,11 @@ pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, W
     let extracted_infos = extract_secret_infos(secret_config_files)?;
 
     let mut config = Config::load_from_default_path()?;
-    let wk_client = WKClient::for_channel(&config, &context.channel)?;
-    let vault_token = vault::get_token_or_login(&mut config).await?;
+    let mut wk_client = WKClient::for_channel(&config, &context.channel)?;
+    let vault_token = vault_token_for(&extracted_infos, &mut config).await?;
 
     let mut has_error = false;
-    let mut secrets_cache: HashMap<String, FetchSecretsData> = HashMap::new();
+    let mut secrets_cache: HashMap<(String, String), FetchSecretsData> = HashMap::new();
 
     for info in extracted_infos {
         eprintln!();
@@ -55,12 +54,13 @@ pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, W
         for annotation in info.1 {
             let source_path = annotation.src.clone();
             let destination_path = annotation.destination_file.clone();
+            let cache_key = (annotation.provider.clone(), source_path.clone());
 
             let file_path = get_local_config_path(&destination_path, &info.0);
 
-            // cache the secrets so we don't call vault api multiple times for the same
-            // path
-            let secret = match secrets_cache.get(&source_path) {
+            // cache the secrets so we don't call the remote multiple times for the
+            // same (provider, path)
+            let secret = match secrets_cache.get(&cache_key) {
                 Some(secrets) => match secrets.data.get(&annotation.name) {
                     Some(secret) => secret.to_string(),
                     None => {
@@ -77,7 +77,13 @@ pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, W
                     }
                 },
                 None => {
-                    let secrets = match wk_client.get_secrets(&vault_token, &source_path).await {
+                    let fetch_result = if annotation.provider == "wukong" {
+                        let (app, ns, path) = parse_wukong_src(&source_path);
+                        wk_client.get_wukong_secrets(&app, &ns, &path).await
+                    } else {
+                        wk_client.get_secrets(&vault_token, &source_path).await
+                    };
+                    let secrets = match fetch_result {
                         Ok(secrets) => secrets,
                         Err(err) => {
                             debug!("Error while fetching secrets: {:?}", &source_path);
@@ -92,10 +98,10 @@ pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, W
                             continue;
                         }
                     };
-                    secrets_cache.insert(source_path.clone(), secrets);
+                    secrets_cache.insert(cache_key.clone(), secrets);
 
                     match secrets_cache
-                        .get(&source_path)
+                        .get(&cache_key)
                         .unwrap()
                         .data
                         .get(&annotation.name)

--- a/cli/src/commands/dev/config/push.rs
+++ b/cli/src/commands/dev/config/push.rs
@@ -5,7 +5,6 @@ use owo_colors::OwoColorize;
 use wukong_sdk::secret_extractors::SecretInfo;
 
 use crate::{
-    auth::vault,
     commands::{dev::config::utils::make_path_relative, Context},
     config::Config,
     error::{DevConfigError, WKCliError},
@@ -17,8 +16,8 @@ use crate::{
 use super::{
     diff::print_diff,
     utils::{
-        extract_secret_infos, get_local_config_as_string, get_local_config_path,
-        get_secret_config_files, get_updated_configs,
+        extract_secret_infos, get_local_config_path, get_secret_config_files, get_updated_configs,
+        parse_wukong_src, vault_token_for,
     },
 };
 use wukong_telemetry::*;
@@ -46,14 +45,15 @@ pub async fn handle_config_push(context: Context) -> Result<bool, WKCliError> {
     }
 
     let mut config = Config::load_from_default_path()?;
-    let wk_client = WKClient::for_channel(&config, &context.channel)?;
-    let vault_token = vault::get_token_or_login(&mut config).await?;
+    let mut wk_client = WKClient::for_channel(&config, &context.channel)?;
+    let vault_token = vault_token_for(&extracted_infos, &mut config).await?;
 
-    let updated_configs = get_updated_configs(&wk_client, &vault_token, &extracted_infos).await?;
+    let updated_configs =
+        get_updated_configs(&mut wk_client, &vault_token, &extracted_infos).await?;
 
     if updated_configs.is_empty() {
         println!(
-            "The config file is already up to date with the Vault Bunker. There are no changes to push."
+            "The config file is already up to date with the remote. There are no changes to push."
         );
 
         return Ok(true);
@@ -64,36 +64,48 @@ pub async fn handle_config_push(context: Context) -> Result<bool, WKCliError> {
             "{}",
             "There is only one config file to update...".bright_yellow()
         );
-        let (annotation, _, _, config_path) = updated_configs.first().unwrap();
+        let (annotation, remote_config, local_config, config_path) =
+            updated_configs.first().unwrap();
 
-        update_secrets(&wk_client, &vault_token, &(config_path.clone(), annotation)).await?;
+        update_secrets(
+            &mut wk_client,
+            &vault_token,
+            annotation,
+            config_path,
+            remote_config,
+            local_config,
+        )
+        .await?;
     } else {
-        let config_to_update = select_config(&updated_configs).await;
-        update_secrets(&wk_client, &vault_token, &config_to_update).await?;
+        let (annotation, remote_config, local_config, config_path) =
+            select_config(&updated_configs).await;
+        update_secrets(
+            &mut wk_client,
+            &vault_token,
+            annotation,
+            &config_path,
+            &remote_config,
+            &local_config,
+        )
+        .await?;
     }
 
     Ok(true)
 }
 
 async fn update_secrets(
-    wk_client: &WKClient,
+    wk_client: &mut WKClient,
     vault_token: &str,
-    config_to_update: &(String, &SecretInfo),
+    secret_info: &SecretInfo,
+    config_path: &str,
+    remote_config: &str,
+    local_config_string: &str,
 ) -> Result<(), WKCliError> {
-    let (config_path, secret_info) = config_to_update;
-
-    let local_config_string =
-        get_local_config_as_string(&secret_info.destination_file, config_path)?;
-
-    let remote_config = wk_client
-        .get_secret(vault_token, &secret_info.src, &secret_info.name)
-        .await?;
-
     let local_config_path = get_local_config_path(config_path, &secret_info.destination_file);
 
     print_diff(
-        &remote_config,
-        &local_config_string,
+        remote_config,
+        local_config_string,
         &local_config_path.to_string_lossy(),
     );
 
@@ -103,15 +115,22 @@ async fn update_secrets(
         .interact()?;
 
     let mut secrets_ref: HashMap<&str, &str> = HashMap::new();
-    secrets_ref.insert(&secret_info.name, &local_config_string);
+    secrets_ref.insert(&secret_info.name, local_config_string);
 
     if agree_to_update {
         let loader = new_spinner();
         loader.set_message("Updating secrets... ");
 
-        wk_client
-            .update_secret(vault_token, &secret_info.src, &secrets_ref)
-            .await?;
+        if secret_info.provider == "wukong" {
+            let (app, ns, path) = parse_wukong_src(&secret_info.src);
+            wk_client
+                .update_wukong_secrets(&app, &ns, &path, &secrets_ref)
+                .await?;
+        } else {
+            wk_client
+                .update_secret(vault_token, &secret_info.src, &secrets_ref)
+                .await?;
+        }
 
         colored_println!("Successfully updated the secrets.");
     }
@@ -121,7 +140,7 @@ async fn update_secrets(
 
 async fn select_config<'a>(
     available_config: &[(&'a SecretInfo, String, String, String)],
-) -> (String, &'a SecretInfo) {
+) -> (&'a SecretInfo, String, String, String) {
     let selection = Select::with_theme(&ColorfulTheme::default())
         .items(
             &available_config
@@ -130,11 +149,16 @@ async fn select_config<'a>(
                     let local_config_path =
                         get_local_config_path(config_path, &secret_info.destination_file);
 
+                    let remote_display = if secret_info.provider == "wukong" {
+                        format!("wukong:{}#{}", secret_info.src, secret_info.name)
+                    } else {
+                        format!("vault:secret/{}#{}", secret_info.src, secret_info.name)
+                    };
+
                     format!(
-                        "{:<50}vault:secret/{}#{}",
+                        "{:<50}{}",
                         make_path_relative(&local_config_path.to_string_lossy()),
-                        secret_info.src,
-                        secret_info.name,
+                        remote_display,
                     )
                 })
                 .collect::<Vec<String>>(),
@@ -150,8 +174,14 @@ async fn select_config<'a>(
 
     return match selection {
         Some(index) => {
-            let (secret_info, _, _, config_path) = available_config.get(index).unwrap();
-            (config_path.clone(), secret_info)
+            let (secret_info, remote_config, local_config, config_path) =
+                available_config.get(index).unwrap();
+            (
+                secret_info,
+                remote_config.clone(),
+                local_config.clone(),
+                config_path.clone(),
+            )
         }
         None => {
             println!("No selection made, exiting...");

--- a/cli/src/commands/dev/config/utils.rs
+++ b/cli/src/commands/dev/config/utils.rs
@@ -11,12 +11,54 @@ use wukong_sdk::secret_extractors::{
 
 use super::diff::has_diff;
 use crate::{
+    auth::vault,
+    config::Config,
     error::{DevConfigError, WKCliError},
     wukong_client::WKClient,
 };
 
+/// Acquire a Vault (bunker) token only when at least one extracted entry
+/// actually needs it. Returns an empty string for the pure-`wukong` case so
+/// callers can pass it through unchanged.
+pub async fn vault_token_for(
+    extracted_infos: &[(String, Vec<SecretInfo>)],
+    config: &mut Config,
+) -> Result<String, WKCliError> {
+    let needs_bunker = extracted_infos
+        .iter()
+        .any(|(_, infos)| infos.iter().any(|i| i.provider == "bunker"));
+    if needs_bunker {
+        vault::get_token_or_login(config).await
+    } else {
+        Ok(String::new())
+    }
+}
+
+/// Split a wukong-provider `src` (`APPLICATION/NAMESPACE/PATH...`) into its
+/// three components.
+///
+/// Relies on `WKTomlConfigExtractor` having already validated at least three
+/// non-empty segments; panics otherwise rather than forwarding empty strings
+/// to the backend.
+pub fn parse_wukong_src(src: &str) -> (String, String, String) {
+    let mut parts = src.splitn(3, '/');
+    let application = parts
+        .next()
+        .expect("parse_wukong_src: application segment missing")
+        .to_string();
+    let namespace = parts
+        .next()
+        .expect("parse_wukong_src: namespace segment missing")
+        .to_string();
+    let path = parts
+        .next()
+        .expect("parse_wukong_src: path segment missing")
+        .to_string();
+    (application, namespace, path)
+}
+
 pub async fn get_updated_configs<'a>(
-    wk_client: &WKClient,
+    wk_client: &mut WKClient,
     vault_token: &str,
     config_files: &'a Vec<(String, Vec<SecretInfo>)>,
 ) -> Result<Vec<(&'a SecretInfo, String, String, String)>, WKCliError> {
@@ -28,7 +70,12 @@ pub async fn get_updated_configs<'a>(
     for config_file in config_files {
         let (config_path, secret_infos) = config_file;
         for info in secret_infos {
-            let remote_secrets = wk_client.get_secrets(vault_token, &info.src).await?.data;
+            let remote_secrets = if info.provider == "wukong" {
+                let (app, ns, path) = parse_wukong_src(&info.src);
+                wk_client.get_wukong_secrets(&app, &ns, &path).await?.data
+            } else {
+                wk_client.get_secrets(vault_token, &info.src).await?.data
+            };
 
             let local_config = match get_local_config_as_string(&info.destination_file, config_path)
             {
@@ -48,9 +95,12 @@ pub async fn get_updated_configs<'a>(
                 }
             };
 
-            // Get only one key from hashmap
+            // Get only one key from hashmap. For the `wukong` provider, a
+            // missing key means the path is new — treat it as an empty remote
+            // and let `push` upsert. Bunker keeps the existing strict behavior.
             let remote_config = match remote_secrets.get(&info.name) {
-                Some(config) => config,
+                Some(config) => config.clone(),
+                None if info.provider == "wukong" => String::new(),
                 None => {
                     return Err(WKCliError::DevConfigError(
                         DevConfigError::InvalidSecretPath {
@@ -61,13 +111,8 @@ pub async fn get_updated_configs<'a>(
                 }
             };
 
-            if has_diff(remote_config, &local_config) {
-                updated_configs.push((
-                    info,
-                    remote_config.clone(),
-                    local_config,
-                    config_path.clone(),
-                ));
+            if has_diff(&remote_config, &local_config) {
+                updated_configs.push((info, remote_config, local_config, config_path.clone()));
             }
         }
     }

--- a/cli/src/wukong_client.rs
+++ b/cli/src/wukong_client.rs
@@ -327,6 +327,39 @@ impl WKClient {
         self.inner.update_secret(api_token, path, data).await
     }
 
+    #[wukong_telemetry(api_event = "fetch_wukong_secrets")]
+    pub async fn get_wukong_secrets(
+        &mut self,
+        application: &str,
+        namespace: &str,
+        path: &str,
+    ) -> Result<FetchSecretsData, WKCliError> {
+        self.check_and_refresh_tokens().await?;
+        let result: Result<FetchSecretsData, WKCliError> = self
+            .inner
+            .get_wukong_secrets(application, namespace, path)
+            .await
+            .map_err(WKCliError::from);
+        result
+    }
+
+    #[wukong_telemetry(api_event = "update_wukong_secrets")]
+    pub async fn update_wukong_secrets(
+        &mut self,
+        application: &str,
+        namespace: &str,
+        path: &str,
+        data: &HashMap<&str, &str>,
+    ) -> Result<bool, WKCliError> {
+        self.check_and_refresh_tokens().await?;
+        let result: Result<bool, WKCliError> = self
+            .inner
+            .update_wukong_secrets(application, namespace, path, data)
+            .await
+            .map_err(WKCliError::from);
+        result
+    }
+
     #[wukong_telemetry(api_event = "fetch_appsignal_average_error_rate")]
     pub async fn fetch_appsignal_average_error_rate(
         &mut self,

--- a/cli/tests/application.rs
+++ b/cli/tests/application.rs
@@ -96,6 +96,7 @@ enable = true
 
 [[application.namespaces]]
 type = "prod"
+continuous_delivery = false
 "#,
         )
         .unwrap();
@@ -188,6 +189,7 @@ enable = true
 
 [[application.namespaces]]
 type = "prod"
+continuous_delivery = false
 "#,
         )
         .unwrap();

--- a/cli/tests/application_instances.rs
+++ b/cli/tests/application_instances.rs
@@ -101,6 +101,7 @@ enable = true
 
 [[application.namespaces]]
 type = "prod"
+continuous_delivery = false
 "#,
         )
         .unwrap();
@@ -182,6 +183,7 @@ enable = true
 
 [[application.namespaces]]
 type = "prod"
+continuous_delivery = false
 "#,
         )
         .unwrap();

--- a/cli/tests/deployment.rs
+++ b/cli/tests/deployment.rs
@@ -95,6 +95,7 @@ enable = true
 
 [[application.namespaces]]
 type = "prod"
+continuous_delivery = false
 "#,
         )
         .unwrap();
@@ -151,6 +152,7 @@ enable = true
 
 [[application.namespaces]]
 type = "prod"
+continuous_delivery = false
 "#,
         )
         .unwrap();

--- a/cli/tests/snapshots/dev_config__wukong_dev_config_diff_when_no_changes_found.snap
+++ b/cli/tests/snapshots/dev_config__wukong_dev_config_diff_when_no_changes_found.snap
@@ -3,5 +3,5 @@ source: tests/dev_config.rs
 expression: "std::str::from_utf8(&output.stdout).unwrap()"
 ---
 [36mcomparing local config vs remote config...[39m
-The config file is already up to date with the Vault Bunker.
+The config file is already up to date with the remote.
 

--- a/cli/tests/snapshots/wukong__wukong_version_without_config_file.snap
+++ b/cli/tests/snapshots/wukong__wukong_version_without_config_file.snap
@@ -2,4 +2,4 @@
 source: cli/tests/wukong.rs
 expression: "std::str::from_utf8(&output.stdout).unwrap()"
 ---
-wukong 2.1.2
+wukong 2.1.3

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.81.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/sdk/src/graphql/application_secret.rs
+++ b/sdk/src/graphql/application_secret.rs
@@ -1,0 +1,17 @@
+use graphql_client::GraphQLQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/schema.json",
+    query_path = "src/graphql/query/application_secrets.graphql",
+    response_derives = "Debug, Serialize, Deserialize"
+)]
+pub struct ApplicationSecretsQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/schema.json",
+    query_path = "src/graphql/mutation/update_application_secrets.graphql",
+    response_derives = "Debug, Serialize, Deserialize"
+)]
+pub struct UpdateApplicationSecrets;

--- a/sdk/src/graphql/deployment_github.rs
+++ b/sdk/src/graphql/deployment_github.rs
@@ -84,7 +84,7 @@ mod test {
 
         let pipeline = response.unwrap().cd_pipeline.unwrap();
 
-        assert!(pipeline.github_builds.len() > 0);
+        assert!(!pipeline.github_builds.is_empty());
     }
 
     #[tokio::test]

--- a/sdk/src/graphql/mod.rs
+++ b/sdk/src/graphql/mod.rs
@@ -1,4 +1,5 @@
 pub mod application;
+pub mod application_secret;
 pub mod appsignal;
 pub mod changelog;
 pub mod deployment;
@@ -15,6 +16,10 @@ pub use self::{
     application::{
         application_config_query, application_query, application_with_k8s_cluster_query,
         applications_query, ApplicationQuery, ApplicationWithK8sClusterQuery, ApplicationsQuery,
+    },
+    application_secret::{
+        application_secrets_query, update_application_secrets, ApplicationSecretsQuery,
+        UpdateApplicationSecrets,
     },
     appsignal::{
         appsignal_apps_query, appsignal_average_error_rate_query, appsignal_average_latency_query,
@@ -38,11 +43,13 @@ pub use self::{
 };
 use crate::{
     error::{APIError, WKError},
+    services::vault::client::FetchSecretsData,
     ApiChannel, WKClient,
 };
 use graphql_client::{GraphQLQuery, Response};
 use log::debug;
 use reqwest::header;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::{thread, time};
 
@@ -731,6 +738,71 @@ impl WKClient {
             )
             .await
             .map_err(|err| err.into())
+    }
+
+    /// Fetch all secrets stored under (`application`, `namespace`, `path`)
+    /// from the Wukong API Proxy. Returned as [`FetchSecretsData`] so the
+    /// shape matches the bunker provider for downstream consumption.
+    pub async fn get_wukong_secrets(
+        &self,
+        application: &str,
+        namespace: &str,
+        path: &str,
+    ) -> Result<FetchSecretsData, WKError> {
+        let gql_client = setup_gql_client(&self.access_token, &self.channel)?;
+
+        let response = gql_client
+            .post_graphql::<ApplicationSecretsQuery, _>(
+                &self.api_url,
+                application_secrets_query::Variables {
+                    application: application.to_string(),
+                    namespace: namespace.to_string(),
+                    path: path.to_string(),
+                },
+            )
+            .await?;
+
+        let data = response
+            .application_secrets
+            .into_iter()
+            .map(|s| (s.key, s.value))
+            .collect::<HashMap<String, String>>();
+
+        Ok(FetchSecretsData { data })
+    }
+
+    /// Upsert secrets at (`application`, `namespace`, `path`) on the Wukong
+    /// API Proxy. Keys not in `data` are left untouched (merge semantics).
+    pub async fn update_wukong_secrets(
+        &self,
+        application: &str,
+        namespace: &str,
+        path: &str,
+        data: &HashMap<&str, &str>,
+    ) -> Result<bool, WKError> {
+        let gql_client = setup_gql_client(&self.access_token, &self.channel)?;
+
+        let secrets = data
+            .iter()
+            .map(|(k, v)| update_application_secrets::ApplicationSecretInput {
+                key: (*k).to_string(),
+                value: (*v).to_string(),
+            })
+            .collect();
+
+        let response = gql_client
+            .post_graphql::<UpdateApplicationSecrets, _>(
+                &self.api_url,
+                update_application_secrets::Variables {
+                    application: application.to_string(),
+                    namespace: namespace.to_string(),
+                    path: path.to_string(),
+                    secrets,
+                },
+            )
+            .await?;
+
+        Ok(response.update_application_secrets)
     }
 }
 

--- a/sdk/src/graphql/mod.rs
+++ b/sdk/src/graphql/mod.rs
@@ -784,10 +784,12 @@ impl WKClient {
 
         let secrets = data
             .iter()
-            .map(|(k, v)| update_application_secrets::ApplicationSecretInput {
-                key: (*k).to_string(),
-                value: (*v).to_string(),
-            })
+            .map(
+                |(k, v)| update_application_secrets::ApplicationSecretInput {
+                    key: (*k).to_string(),
+                    value: (*v).to_string(),
+                },
+            )
             .collect();
 
         let response = gql_client

--- a/sdk/src/graphql/mutation/update_application_secrets.graphql
+++ b/sdk/src/graphql/mutation/update_application_secrets.graphql
@@ -1,0 +1,13 @@
+mutation UpdateApplicationSecrets(
+  $application: String!
+  $namespace: String!
+  $path: String!
+  $secrets: [ApplicationSecretInput!]!
+) {
+  updateApplicationSecrets(
+    application: $application
+    namespace: $namespace
+    path: $path
+    secrets: $secrets
+  )
+}

--- a/sdk/src/graphql/query/application_secrets.graphql
+++ b/sdk/src/graphql/query/application_secrets.graphql
@@ -1,0 +1,14 @@
+query ApplicationSecretsQuery(
+  $application: String!
+  $namespace: String!
+  $path: String!
+) {
+  applicationSecrets(
+    application: $application
+    namespace: $namespace
+    path: $path
+  ) {
+    key
+    value
+  }
+}

--- a/sdk/src/graphql/schema.json
+++ b/sdk/src/graphql/schema.json
@@ -4427,6 +4427,87 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "application",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "namespace",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "path",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "secrets",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "ApplicationSecretInput",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Upsert vault-powered secrets for an application/namespace/path.",
+              "isDeprecated": false,
+              "name": "updateApplicationSecrets",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
             }
           ],
           "inputFields": null,
@@ -5731,6 +5812,73 @@
                   }
                 }
               }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "application",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "namespace",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "path",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "List vault-powered secrets for an application/namespace/path.",
+              "isDeprecated": false,
+              "name": "applicationSecrets",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ApplicationSecret",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
             }
           ],
           "inputFields": null,
@@ -5925,6 +6073,88 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "Throughput",
+          "possibleTypes": null
+        },
+        {
+          "description": "A single application secret (vault-powered provider).",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "key",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "value",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ApplicationSecret",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "key",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "value",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "ApplicationSecretInput",
           "possibleTypes": null
         }
       ]

--- a/sdk/src/utils/secret_extractors/wk_toml_config.rs
+++ b/sdk/src/utils/secret_extractors/wk_toml_config.rs
@@ -90,12 +90,13 @@ impl SecretExtractor for WKTomlConfigExtractor {
                                 }
                             };
 
-                            // we are ignoring configs if provider is not "bunker" and kind is not
-                            // "generic" for now
-                            if provider != "bunker" || kind != "generic" {
+                            if kind != "generic" {
                                 continue;
                             }
 
+                            // Split the `#fragment` off `src` to get the secret name.
+                            // This is shared between bunker (`vault:secret/PATH#NAME`)
+                            // and url (`https://HOST/PATH#NAME`) providers.
                             let value_part = source.split('#').collect::<Vec<&str>>();
                             if value_part.len() != 2 {
                                 continue;
@@ -103,19 +104,68 @@ impl SecretExtractor for WKTomlConfigExtractor {
                             let source = value_part[0].to_string();
                             let secret_name = value_part[1].to_string();
 
-                            let splited_source_and_path = source.split(':').collect::<Vec<&str>>();
-                            if splited_source_and_path.len() != 2 {
-                                continue;
-                            }
-                            let path_with_engine = splited_source_and_path[1].to_string();
+                            let src = match provider.as_str() {
+                                "bunker" => {
+                                    let splited_source_and_path =
+                                        source.split(':').collect::<Vec<&str>>();
+                                    if splited_source_and_path.len() != 2 {
+                                        continue;
+                                    }
+                                    let path_with_engine =
+                                        splited_source_and_path[1].to_string();
 
-                            let splited_engine_and_path =
-                                path_with_engine.split('/').collect::<Vec<&str>>();
-                            let (engine, path) = splited_engine_and_path.split_at(1);
+                                    let splited_engine_and_path =
+                                        path_with_engine.split('/').collect::<Vec<&str>>();
+                                    let (engine, path) = splited_engine_and_path.split_at(1);
 
-                            if (splited_source_and_path[0] != "vault") || (engine[0] != "secret") {
-                                continue;
-                            }
+                                    if (splited_source_and_path[0] != "vault")
+                                        || (engine[0] != "secret")
+                                    {
+                                        continue;
+                                    }
+
+                                    path.join("/")
+                                }
+                                "wukong" => {
+                                    // Expect: wukong:APPLICATION/NAMESPACE/PATH...#KEY
+                                    // (`#KEY` was already split into `secret_name`)
+                                    let scheme_split =
+                                        source.split(':').collect::<Vec<&str>>();
+                                    if scheme_split.len() != 2 || scheme_split[0] != "wukong" {
+                                        eprintln!(
+                                            "⚠️  [wukong_toml] The {} entry has provider = \"wukong\" but {} does not match {}. It will be ignored.",
+                                            key.cyan(),
+                                            "src".cyan(),
+                                            "wukong:APPLICATION/NAMESPACE/PATH#KEY".cyan()
+                                        );
+                                        continue;
+                                    }
+                                    let segments =
+                                        scheme_split[1].split('/').collect::<Vec<&str>>();
+                                    if segments.len() < 3
+                                        || segments.iter().any(|s| s.is_empty())
+                                    {
+                                        eprintln!(
+                                            "⚠️  [wukong_toml] The {} entry needs at least application/namespace/path after the {} scheme. It will be ignored.",
+                                            key.cyan(),
+                                            "wukong:".cyan()
+                                        );
+                                        continue;
+                                    }
+                                    // Store the slash-joined APP/NS/PATH form in `src`;
+                                    // the dispatch sites split it back into the
+                                    // (application, namespace, path) tuple.
+                                    scheme_split[1].to_string()
+                                }
+                                _ => {
+                                    eprintln!(
+                                        "⚠️  [wukong_toml] Unknown provider {:?} under {} table. It will be ignored.",
+                                        provider,
+                                        key.cyan()
+                                    );
+                                    continue;
+                                }
+                            };
 
                             if (destination_file.starts_with("~/"))
                                 || (destination_file.starts_with('/'))
@@ -126,8 +176,6 @@ impl SecretExtractor for WKTomlConfigExtractor {
                                 );
                                 continue;
                             }
-
-                            let src = path.join("/");
 
                             extracted.push(SecretInfo {
                                 key: key.to_string(),
@@ -199,6 +247,54 @@ dst = "priv/files/kubeconfig"
         assert_eq!(secret_infos[1].provider, "bunker");
         assert_eq!(secret_infos[1].kind, "generic");
         assert_eq!(secret_infos[1].annotated_file, dev_config_path);
+
+        dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_wk_toml_config_extractor_wukong_provider() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let dev_config_path = dir.path().join(".wukong.toml");
+
+        let mut dev_config = File::create(&dev_config_path).unwrap();
+        writeln!(
+            dev_config,
+            r#"
+[[secrets]]
+
+[secrets.dotenv]
+provider = "wukong"
+kind = "generic"
+src = "wukong:mv-platform/staging/wukong-cli/development#dotenv"
+dst = ".env"
+
+[secrets.too_short]
+provider = "wukong"
+kind = "generic"
+src = "wukong:onlyone#foo"
+dst = "foo.txt"
+
+[secrets.bad_scheme]
+provider = "wukong"
+kind = "generic"
+src = "vault:secret/wukong-cli/development#bar"
+dst = "bar.txt"
+            "#
+        )
+        .unwrap();
+
+        let secret_infos = WKTomlConfigExtractor::extract(&dev_config_path).unwrap();
+
+        assert_eq!(secret_infos.len(), 1);
+        assert_eq!(secret_infos[0].key, "dotenv");
+        assert_eq!(secret_infos[0].name, "dotenv");
+        assert_eq!(
+            secret_infos[0].src,
+            "mv-platform/staging/wukong-cli/development"
+        );
+        assert_eq!(secret_infos[0].destination_file, ".env");
+        assert_eq!(secret_infos[0].provider, "wukong");
+        assert_eq!(secret_infos[0].kind, "generic");
 
         dir.close().unwrap();
     }

--- a/sdk/src/utils/secret_extractors/wk_toml_config.rs
+++ b/sdk/src/utils/secret_extractors/wk_toml_config.rs
@@ -111,8 +111,7 @@ impl SecretExtractor for WKTomlConfigExtractor {
                                     if splited_source_and_path.len() != 2 {
                                         continue;
                                     }
-                                    let path_with_engine =
-                                        splited_source_and_path[1].to_string();
+                                    let path_with_engine = splited_source_and_path[1].to_string();
 
                                     let splited_engine_and_path =
                                         path_with_engine.split('/').collect::<Vec<&str>>();
@@ -129,8 +128,7 @@ impl SecretExtractor for WKTomlConfigExtractor {
                                 "wukong" => {
                                     // Expect: wukong:APPLICATION/NAMESPACE/PATH...#KEY
                                     // (`#KEY` was already split into `secret_name`)
-                                    let scheme_split =
-                                        source.split(':').collect::<Vec<&str>>();
+                                    let scheme_split = source.split(':').collect::<Vec<&str>>();
                                     if scheme_split.len() != 2 || scheme_split[0] != "wukong" {
                                         eprintln!(
                                             "⚠️  [wukong_toml] The {} entry has provider = \"wukong\" but {} does not match {}. It will be ignored.",
@@ -142,9 +140,7 @@ impl SecretExtractor for WKTomlConfigExtractor {
                                     }
                                     let segments =
                                         scheme_split[1].split('/').collect::<Vec<&str>>();
-                                    if segments.len() < 3
-                                        || segments.iter().any(|s| s.is_empty())
-                                    {
+                                    if segments.len() < 3 || segments.iter().any(|s| s.is_empty()) {
                                         eprintln!(
                                             "⚠️  [wukong_toml] The {} entry needs at least application/namespace/path after the {} scheme. It will be ignored.",
                                             key.cyan(),

--- a/sdk/src/utils/secret_extractors/wk_toml_config.rs
+++ b/sdk/src/utils/secret_extractors/wk_toml_config.rs
@@ -117,8 +117,8 @@ impl SecretExtractor for WKTomlConfigExtractor {
                                         path_with_engine.split('/').collect::<Vec<&str>>();
                                     let (engine, path) = splited_engine_and_path.split_at(1);
 
-                                    if (splited_source_and_path[0] != "vault")
-                                        || (engine[0] != "secret")
+                                    if splited_source_and_path[0] != "vault"
+                                        || engine[0] != "secret"
                                     {
                                         continue;
                                     }
@@ -163,8 +163,8 @@ impl SecretExtractor for WKTomlConfigExtractor {
                                 }
                             };
 
-                            if (destination_file.starts_with("~/"))
-                                || (destination_file.starts_with('/'))
+                            if destination_file.starts_with("~/")
+                                || destination_file.starts_with('/')
                             {
                                 eprintln!(
                                 "⚠️  [wukong_toml] The destination {} is not under the project directory. It will be ignored.",


### PR DESCRIPTION
## Summary

Adds a new `provider = "wukong"` for `.wukong.toml` secret entries that routes through the wukong-api-proxy GraphQL endpoint (`applicationSecrets` query + `updateApplicationSecrets` mutation) instead of Bunker. Reuses the Okta `id_token` with the existing refresh flow.

Depends on the wukong-api-proxy backend change that adds `applicationSecrets` / `updateApplicationSecrets` / `ApplicationSecret` / `ApplicationSecretInput` to the Absinthe schema.

## Declaration

```toml
[secrets.dotenv]
provider = "wukong"
kind     = "generic"
src      = "wukong:mv-platform/staging/config#dotenv"
dst      = ".env"
```

Grammar: `wukong: <application> / <namespace> / <path...> # <key>` — `application` and `namespace` must resolve through the backend's existing `ValidateApplicationAndNamespace` middleware; `path` is opaque.

## What changed

- **New** `sdk/src/graphql/{query,mutation,application_secret.rs}` — `graphql_client`-generated `ApplicationSecretsQuery` / `UpdateApplicationSecrets` wrappers.
- **New SDK methods** `WKClient::get_wukong_secrets` / `update_wukong_secrets` in `sdk/src/graphql/mod.rs` — list-of-pairs response converted to the existing `FetchSecretsData { data: HashMap<String,String> }` so downstream code stays untouched.
- **Extractor** (`sdk/src/utils/secret_extractors/wk_toml_config.rs`) — relaxed the bunker-only gate, added a `match provider.as_str()` with a validated `wukong` branch (scheme check + ≥3 non-empty segments + warning on unknown providers).
- **CLI wrappers** (`cli/src/wukong_client.rs`) — `get_wukong_secrets` / `update_wukong_secrets` with `#[wukong_telemetry]` and `check_and_refresh_tokens`.
- **Dispatch** in `pull.rs`, `diff.rs`, `push.rs`, `utils.rs::get_updated_configs` — branch on `provider == "wukong"`, call the parsed `(app, ns, path)` helper.
- **`vault_token_for` helper** — shared across pull/diff/push; skips the Bunker login when no `bunker` entries are present (pure-wukong projects don't get prompted).
- **`push` efficiency** — threads the already-fetched remote value from `get_updated_configs` through `update_secrets`, eliminating a redundant GraphQL round-trip per upsert and a double `parse_wukong_src`.
- **`push` UX fix** — missing key on the remote is treated as a new secret (empty remote) rather than aborting with `InvalidSecretPath`, enabling first-time push to a fresh path.

## schema.json

Since the `graphql_client` macro reads `sdk/src/graphql/schema.json` at compile time, the four new entries (`ApplicationSecret`, `ApplicationSecretInput`, `applicationSecrets` query field, `updateApplicationSecrets` mutation field) are merged in surgically. When a backend schema dump covers both the old and new fields cleanly, this can be swapped for a wholesale regeneration.

## Test plan

- [x] `cargo test -p wukong-sdk --lib` — 24 pass (includes new extractor test for the `wukong` branch)
- [x] `cargo test -p wukong --lib` — 41 pass (pre-existing `application` snapshot failures on `main` are from #233's `continuous_delivery` change, not this PR)
- [x] End-to-end against a local `mix phx.server` wukong-api-proxy: seeded via `updateApplicationSecrets` mutation → `pull` wrote the correct `.env` → local edit → `diff` showed expected changes → `push` upserted → verified via `secret_audit_logs`
- [ ] Reviewer: exercise `pull` / `diff` / `push` against a staging wukong-api-proxy with a real app/namespace in the app list
- [ ] Reviewer: verify a project mixing `bunker` and `wukong` entries in the same `.wukong.toml` works (Okta refresh + Vault login both trigger)
- [ ] Reviewer: confirm the `schema.json` merge is acceptable until the next clean regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)