### PR TITLE
Back up overwritten files on dev config pull

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "wukong"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "aion",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wukong"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2021"
 default-run = "wukong"
 

--- a/cli/src/commands/dev/config/pull.rs
+++ b/cli/src/commands/dev/config/pull.rs
@@ -1,9 +1,9 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     env::current_dir,
-    fs::File,
+    fs::{File, OpenOptions},
     io::{ErrorKind, Write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use log::debug;
@@ -17,11 +17,19 @@ use crate::{
     wukong_client::WKClient,
 };
 
+use super::diff::has_diff;
 use super::utils::{
     extract_secret_infos, get_secret_config_files, parse_wukong_src, vault_token_for,
 };
 use wukong_telemetry::*;
 use wukong_telemetry_macro::*;
+
+/// Suffix appended to the original filename when a pull would overwrite it.
+const BACKUP_SUFFIX: &str = ".bak";
+
+/// Pattern we ensure is present in `.gitignore` so backups never get
+/// accidentally committed.
+const BACKUP_GITIGNORE_PATTERN: &str = "*.bak";
 
 #[wukong_telemetry(command_event = "dev_config_pull")]
 pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, WKCliError> {
@@ -48,6 +56,9 @@ pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, W
 
     let mut has_error = false;
     let mut secrets_cache: HashMap<(String, String), FetchSecretsData> = HashMap::new();
+    // Tracks which `.gitignore` files we've already touched this run so we
+    // don't re-read/append them per annotation.
+    let mut gitignored_dirs: HashSet<PathBuf> = HashSet::new();
 
     for info in extracted_infos {
         eprintln!();
@@ -141,6 +152,19 @@ pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, W
                 };
             }
 
+            // Snapshot the previous version before we overwrite it, but only
+            // when the file actually exists and its content differs from what
+            // we're about to write. First-pull (file absent) and no-op pull
+            // (identical content) both skip backup.
+            if let Some(backup_path) = backup_existing_if_changed(&file_path, &secret) {
+                eprintln!(
+                    "\t{} {}",
+                    "📦 Backed up previous version to".cyan(),
+                    backup_path.to_string_lossy()
+                );
+                ensure_backup_gitignored(&file_path, &info.0, &mut gitignored_dirs);
+            }
+
             match File::create(&file_path) {
                 Ok(mut file) => {
                     if let Err(err) = file.write_all(secret.as_bytes()) {
@@ -178,5 +202,328 @@ pub async fn handle_config_pull(context: Context, path: &Path) -> Result<bool, W
         Ok(false)
     } else {
         Ok(true)
+    }
+}
+
+/// If `file_path` already exists and its content differs from `incoming`,
+/// copy it to a sibling `<name>.bak` (overwriting any prior backup) and
+/// return that path. Otherwise return `None` and write nothing.
+///
+/// Errors during read/write are logged and treated as "no backup" — we never
+/// abort the pull just because a backup attempt failed.
+fn backup_existing_if_changed(file_path: &Path, incoming: &str) -> Option<PathBuf> {
+    let existing = match std::fs::read_to_string(file_path) {
+        Ok(content) => content,
+        // Includes the file-not-found case (first pull) and any other read
+        // failure. We don't try to distinguish — both mean "no backup needed
+        // or possible".
+        Err(err) => {
+            debug!(
+                "skipping backup of {}: {:?}",
+                file_path.to_string_lossy(),
+                err
+            );
+            return None;
+        }
+    };
+
+    if !has_diff(&existing, incoming) {
+        return None;
+    }
+
+    // Build the backup path via OsString so non-UTF-8 filenames survive.
+    let mut name = file_path.file_name()?.to_os_string();
+    name.push(BACKUP_SUFFIX);
+    let backup = file_path.with_file_name(name);
+
+    if let Err(err) = std::fs::copy(file_path, &backup) {
+        debug!(
+            "failed to write backup {}: {:?}",
+            backup.to_string_lossy(),
+            err
+        );
+        return None;
+    }
+
+    Some(backup)
+}
+
+/// Append `*.bak` to the nearest `.gitignore` (walking up from the
+/// destination file, stopping at the directory containing the annotated
+/// config). If no `.gitignore` exists along that chain, create one next to
+/// the annotated config. Idempotent across the run via `seen_dirs`, and
+/// idempotent across runs via a per-line check.
+fn ensure_backup_gitignored(
+    file_path: &Path,
+    annotated_config_path: &str,
+    seen_dirs: &mut HashSet<PathBuf>,
+) {
+    let config_dir = match Path::new(annotated_config_path).parent() {
+        Some(p) => p.to_path_buf(),
+        None => return,
+    };
+
+    let target = find_gitignore_target(file_path, &config_dir);
+
+    if !seen_dirs.insert(target.clone()) {
+        return;
+    }
+
+    // Single read covers both the presence check and the trailing-newline
+    // decision below. Missing file → empty string, which means "create".
+    let content = std::fs::read_to_string(&target).unwrap_or_default();
+    if content
+        .lines()
+        .any(|line| line.trim() == BACKUP_GITIGNORE_PATTERN)
+    {
+        return;
+    }
+
+    let result = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&target)
+        .and_then(|mut f| {
+            // Avoid running the new pattern onto the previous line when the
+            // existing file lacks a trailing newline. An empty file gets no
+            // leading newline.
+            let needs_separator = !content.is_empty() && !content.ends_with('\n');
+            let prefix = if needs_separator { "\n" } else { "" };
+            writeln!(f, "{}{}", prefix, BACKUP_GITIGNORE_PATTERN)
+        });
+
+    match result {
+        Ok(_) => eprintln!(
+            "\t{} {} {}",
+            "🔒 Added".cyan(),
+            BACKUP_GITIGNORE_PATTERN.bold(),
+            format!("to {}", target.to_string_lossy()).cyan()
+        ),
+        Err(err) => debug!("failed to update {}: {:?}", target.to_string_lossy(), err),
+    }
+}
+
+/// Walk upward from `file_path`'s directory until we find an existing
+/// `.gitignore`, stopping at `config_dir`. If none is found (or if the file
+/// somehow lives outside `config_dir`), fall back to creating one in
+/// `config_dir` itself — we never modify a `.gitignore` above the project's
+/// annotated-config root.
+fn find_gitignore_target(file_path: &Path, config_dir: &Path) -> PathBuf {
+    let start = file_path.parent().unwrap_or(config_dir);
+
+    // Defensive: if the destination resolves outside the config root, don't
+    // walk up arbitrary filesystem ancestors looking for a `.gitignore`.
+    if !start.starts_with(config_dir) {
+        return config_dir.join(".gitignore");
+    }
+
+    let mut cursor = Some(start);
+    while let Some(dir) = cursor {
+        let candidate = dir.join(".gitignore");
+        if candidate.exists() {
+            return candidate;
+        }
+        if dir == config_dir {
+            break;
+        }
+        cursor = dir.parent();
+    }
+
+    config_dir.join(".gitignore")
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use assert_fs::prelude::{FileWriteStr, PathChild};
+
+    #[test]
+    fn no_backup_when_file_absent() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let target = dir.child(".env");
+        assert!(backup_existing_if_changed(target.path(), "fresh content").is_none());
+        assert!(!dir.child(".env.bak").path().exists());
+    }
+
+    #[test]
+    fn no_backup_when_content_unchanged() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let target = dir.child(".env");
+        target.write_str("FOO=bar\n").unwrap();
+        assert!(backup_existing_if_changed(target.path(), "FOO=bar\n").is_none());
+        assert!(!dir.child(".env.bak").path().exists());
+    }
+
+    #[test]
+    fn backup_written_when_content_differs() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let target = dir.child(".env");
+        target.write_str("FOO=old\n").unwrap();
+
+        let backup = backup_existing_if_changed(target.path(), "FOO=new\n").unwrap();
+        assert_eq!(backup, dir.child(".env.bak").path());
+
+        let backup_content = std::fs::read_to_string(&backup).unwrap();
+        assert_eq!(backup_content, "FOO=old\n");
+    }
+
+    #[test]
+    fn backup_overwrites_previous_backup() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let target = dir.child(".env");
+        let prior_backup = dir.child(".env.bak");
+        target.write_str("v2\n").unwrap();
+        prior_backup.write_str("v0\n").unwrap();
+
+        let backup = backup_existing_if_changed(target.path(), "v3\n").unwrap();
+        let content = std::fs::read_to_string(&backup).unwrap();
+        // The new backup is the v2 (current), not the stale v0.
+        assert_eq!(content, "v2\n");
+    }
+
+    #[test]
+    fn gitignore_appended_with_separator_when_no_trailing_newline() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let config_path = dir.child(".wukong.toml");
+        config_path.write_str("").unwrap();
+        let gitignore = dir.child(".gitignore");
+        // Existing content with no trailing newline.
+        gitignore.write_str("node_modules").unwrap();
+        let env_path = dir.child(".env");
+
+        let mut seen = HashSet::new();
+        ensure_backup_gitignored(
+            env_path.path(),
+            &config_path.path().to_string_lossy(),
+            &mut seen,
+        );
+
+        let content = std::fs::read_to_string(gitignore.path()).unwrap();
+        // Should be `node_modules\n*.bak\n`, not `node_modules*.bak\n`.
+        assert_eq!(content, "node_modules\n*.bak\n");
+    }
+
+    #[test]
+    fn find_gitignore_falls_back_when_dest_outside_config_dir() {
+        let outer = assert_fs::TempDir::new().unwrap();
+        let config_dir = outer.child("project");
+        std::fs::create_dir_all(config_dir.path()).unwrap();
+        // A file living outside the project root (e.g. someone abusing `..`).
+        let escaped = outer.child("escape/.env");
+
+        let target = find_gitignore_target(escaped.path(), config_dir.path());
+        // Must NOT walk up into `outer` looking for a .gitignore — must
+        // fall back to the project root.
+        assert_eq!(target, config_dir.child(".gitignore").path());
+    }
+
+    #[test]
+    fn gitignore_created_when_missing() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let config_path = dir.child(".wukong.toml");
+        config_path.write_str("").unwrap();
+        let env_path = dir.child(".env");
+
+        let mut seen = HashSet::new();
+        ensure_backup_gitignored(
+            env_path.path(),
+            &config_path.path().to_string_lossy(),
+            &mut seen,
+        );
+
+        let gitignore = dir.child(".gitignore");
+        assert!(gitignore.path().exists());
+        let content = std::fs::read_to_string(gitignore.path()).unwrap();
+        assert!(content.contains(BACKUP_GITIGNORE_PATTERN));
+    }
+
+    #[test]
+    fn gitignore_appended_when_pattern_missing() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let config_path = dir.child(".wukong.toml");
+        config_path.write_str("").unwrap();
+        let gitignore = dir.child(".gitignore");
+        gitignore.write_str("node_modules\n").unwrap();
+        let env_path = dir.child(".env");
+
+        let mut seen = HashSet::new();
+        ensure_backup_gitignored(
+            env_path.path(),
+            &config_path.path().to_string_lossy(),
+            &mut seen,
+        );
+
+        let content = std::fs::read_to_string(gitignore.path()).unwrap();
+        assert!(content.contains("node_modules"));
+        assert!(content.contains(BACKUP_GITIGNORE_PATTERN));
+    }
+
+    #[test]
+    fn gitignore_not_modified_when_pattern_present() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let config_path = dir.child(".wukong.toml");
+        config_path.write_str("").unwrap();
+        let gitignore = dir.child(".gitignore");
+        let original = format!("node_modules\n{}\n", BACKUP_GITIGNORE_PATTERN);
+        gitignore.write_str(&original).unwrap();
+        let env_path = dir.child(".env");
+
+        let mut seen = HashSet::new();
+        ensure_backup_gitignored(
+            env_path.path(),
+            &config_path.path().to_string_lossy(),
+            &mut seen,
+        );
+
+        let content = std::fs::read_to_string(gitignore.path()).unwrap();
+        assert_eq!(content, original);
+    }
+
+    #[test]
+    fn gitignore_only_touched_once_per_run() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let config_path = dir.child(".wukong.toml");
+        config_path.write_str("").unwrap();
+        let env_path = dir.child(".env");
+
+        let mut seen = HashSet::new();
+        ensure_backup_gitignored(
+            env_path.path(),
+            &config_path.path().to_string_lossy(),
+            &mut seen,
+        );
+        // Simulate a second annotation in the same run.
+        let other_path = dir.child(".env.local");
+        ensure_backup_gitignored(
+            other_path.path(),
+            &config_path.path().to_string_lossy(),
+            &mut seen,
+        );
+
+        let content = std::fs::read_to_string(dir.child(".gitignore").path()).unwrap();
+        let occurrences = content.matches(BACKUP_GITIGNORE_PATTERN).count();
+        assert_eq!(occurrences, 1);
+    }
+
+    #[test]
+    fn find_gitignore_walks_up_to_existing() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let config_path = dir.child(".wukong.toml");
+        config_path.write_str("").unwrap();
+        let root_gitignore = dir.child(".gitignore");
+        root_gitignore.write_str("").unwrap();
+
+        // Destination is nested 2 dirs deep; should resolve to the root .gitignore.
+        let nested = dir.child("priv/files/kubeconfig");
+        let target = find_gitignore_target(nested.path(), dir.path());
+        assert_eq!(target, root_gitignore.path());
+    }
+
+    #[test]
+    fn find_gitignore_falls_back_to_config_dir() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let nested = dir.child("priv/files/kubeconfig");
+        let target = find_gitignore_target(nested.path(), dir.path());
+        assert_eq!(target, dir.child(".gitignore").path());
     }
 }


### PR DESCRIPTION
## Summary
- `wukong config dev pull` now snapshots an existing destination to a sibling `.bak` file before overwriting it — only when the new content actually differs from the local copy.
- Auto-appends `*.bak` to the nearest `.gitignore` (capped at the annotated config dir) so backups never get committed accidentally.
- Backup failures degrade silently to debug logs — they never abort the pull.
- Bumped cli `2.1.2` → `2.1.3`.

Behavior:
- First pull (file absent): no backup, just create.
- No-op pull (identical content): no backup.
- Overwriting pull: previous version copied to `<file>.bak`, prior `.bak` is replaced (single slot, latest only).
- Per-pull `.gitignore` mutation is idempotent across runs and only touched once per invocation.

## Test plan
- [x] `cargo test -p wukong --lib commands::dev::config` → 16/16 pass (12 new unit tests covering: backup absent/unchanged/changed/overwrite, gitignore created/appended/idempotent/once-per-run/separator-handling, walk-up bounded by config dir).
- [x] `cargo build -p wukong --bin wukong` clean.
- [ ] Manual `wukong config dev pull` against a real bunker config: confirm `.bak` is created, contents match the previous local file, `.gitignore` gets `*.bak` appended.
- [ ] Verify nothing happens on the second consecutive pull when content is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)