### PR TITLE
Remove rust-toolchain.toml (fixes Linux cross build)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "1.81.0"
-components = ["rustfmt", "clippy"]
-profile = "minimal"


### PR DESCRIPTION
## Summary

The `rust-toolchain.toml` shipped in #235 pinned the workspace to Rust 1.81.0. This broke the Linux build job in CI because `cargo install cross` (triggered by `use-cross: true` in the `ci` matrix) resolves `getrandom 0.4.2` as a transitive dep, and `getrandom 0.4.2` requires `edition2024` — stabilized only in Rust 1.85+.

CI error:
```
error: failed to compile `cross v0.2.5`
  Caused by: feature `edition2024` is required
    The package requires the Cargo feature called `edition2024`,
    but that feature is not stabilized in this version of Cargo
    (1.81.0 (2dbb1af80 2024-08-20)).
```

The pin was added in #235 so contributors could reproduce CI's lint errors locally. That value stays available without shipping the pin — anyone can set it per-checkout:

```bash
rustup override set 1.81.0
```

## Test plan
- [ ] CI's `check-formatting-clippy` job still runs 1.81.0 (explicit `dtolnay/rust-toolchain@stable toolchain: 1.81.0`) — unchanged
- [ ] CI's `ci` matrix (macOS/Linux cross builds) resolves to latest stable as originally intended
- [ ] Linux `cargo install cross` no longer blocked by edition2024 requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)