### PR TITLE
[CEH-380] Gate release publish job on release-publish environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,7 @@ jobs:
   publish:
     needs: [build-release]
     runs-on: ubuntu-22.04
+    environment: release-publish
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `environment: release-publish` to the `publish` job in `.github/workflows/release.yml` so the Homebrew tap update is gated on a required-reviewer approval.
- Cloud Engineering will create the `release-publish` environment with reviewers; this YAML line is what wires the gate to the publish job.
- Addresses item 2 of [CEH-380](https://mindvalley.atlassian.net/browse/CEH-380) (publish-job approval gate).

## Test plan
- [ ] Cloud Engineering confirms `release-publish` environment exists with required reviewers
- [ ] Next release tag push pauses on the `publish` job awaiting approval
- [ ] Approver clicks approve and the Homebrew formula PR is created as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CEH-380]: https://mindvalley.atlassian.net/browse/CEH-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ