### PR TITLE
chore: bump version to 2.1.4-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "wukong"
-version = "2.1.3"
+version = "2.1.4-beta.1"
 dependencies = [
  "aion",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wukong"
-version = "2.1.3"
+version = "2.1.4-beta.1"
 edition = "2021"
 default-run = "wukong"
 

--- a/cli/tests/snapshots/wukong__wukong_version_without_config_file.snap
+++ b/cli/tests/snapshots/wukong__wukong_version_without_config_file.snap
@@ -2,4 +2,4 @@
 source: cli/tests/wukong.rs
 expression: "std::str::from_utf8(&output.stdout).unwrap()"
 ---
-wukong 2.1.3
+wukong 2.1.4-beta.1


### PR DESCRIPTION
## Summary
- Bump CLI version from 2.1.3 to 2.1.4-beta.1

## Test plan
- [x] CI passes
- [ ] After merge, tag `2.1.4-beta.1` to trigger release workflow