### PR TITLE
ci(release): attribute homebrew formula commits to mvwebmaster

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,11 +239,12 @@ jobs:
       - name: Create a new PR to bump version
         env:
           DEBUG: api
+          GH_EMAIL: ${{ vars.GH_EMAIL }}
         run: |
           VERSION=${{ env.TAG_NAME }}
           NEW_BRANCH_NAME="release/${VERSION}"
 
-          git config --global user.email "mvwebmaster@mindvalley.com"
+          git config --global user.email "${GH_EMAIL}"
           git config --global user.name "mvwebmaster"
 
           git branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,8 +243,8 @@ jobs:
           VERSION=${{ env.TAG_NAME }}
           NEW_BRANCH_NAME="release/${VERSION}"
 
-          git config --global user.email "junkai.gan@mindvalley.com"
-          git config --global user.name "Gan Jun Kai"
+          git config --global user.email "mvwebmaster@mindvalley.com"
+          git config --global user.name "mvwebmaster"
 
           git branch
           git switch -c "${NEW_BRANCH_NAME}"


### PR DESCRIPTION
## Summary
- The Homebrew formula bump step in `.github/workflows/release.yml` hardcoded `git config user.name/email` to Gan Jun Kai's personal identity, so every release commit pushed to `mindvalley/homebrew-wukong` was attributed to `jk-gan` on GitHub.
- Switch the committer name to the `mvwebmaster` bot and read the email from a `GH_EMAIL` GitHub Actions **repository variable** so it can be rotated without code changes.

## Required action before next release
Set the `GH_EMAIL` repository variable under **Settings → Secrets and variables → Actions → Variables** (e.g. `<USER_ID>+mvwebmaster@users.noreply.github.com` for proper GitHub UI attribution). If the variable is empty, the commit will be made with an empty email and may fail commit signing / push rules.

## Test plan
- [ ] `GH_EMAIL` variable set on the repo
- [ ] Next release run pushes a commit to `mindvalley/homebrew-wukong` authored by `mvwebmaster` with the configured email

🤖 Generated with [Claude Code](https://claude.com/claude-code)